### PR TITLE
Changes to allow linking to ncursesw.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,16 +15,22 @@ COLOR_OFF=$(shell tput sgr0)
 COLOR_GREEN=$(shell tput setaf 2)
 PREFIX=${COLOR_GREEN}»»»${COLOR_OFF}
 
+# CFG Directive Options
+CFG_OPT = 
+
 .SILENT:
 
-.PHONY: all clean
+.PHONY: all clean link-ncursesw
 
 all: .build_examples
 	echo "${PREFIX} Finished \o/"
 	
+link-ncursesw: CFG_OPT = --cfg ncursesw
+link-ncursesw: all
+
 .build_lib: .setup_lib ${LIB_SRC}
 	echo "${PREFIX} Building ncurses-rs "
-	rustc --out-dir lib src/lib.rs
+	rustc ${CFG_OPT} --out-dir lib src/lib.rs
 	touch .build_lib
 
 .setup_lib:

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -39,7 +39,9 @@ pub struct MEVENT { id: c_short, x: c_int, y: c_int, z: c_int, bstate: mmask_t}
 #[link(name = "GL")]
 extern { }
 
-#[link(name = "ncurses")]
+macro_rules! define_sharedffi(
+  ($cfgopt:attr, $link:attr) => (
+  $cfgopt  $link
 extern
 {
   pub fn addch(_:chtype) -> c_int;
@@ -361,4 +363,7 @@ extern
   pub fn wmouse_trafo(_:*WINDOW,_:*c_int,_:*c_int,_:c_int) -> c_int;
   pub fn mouse_trafo(_:*c_int,_:*c_int,_:c_int) -> c_int;
 }
+))//end macro rules
 
+define_sharedffi!(#[cfg(ncursesw)], #[link(name="ncursesw")])
+define_sharedffi!(#[cfg(not(ncursesw))], #[link(name="ncurses")])


### PR DESCRIPTION
Basically makes it slightly easier to do unicode stuff on distributions where ncurses != ncursesw.  Of course, it still needs a setlocale call, but it's one step closer to simple-ish unicode ncurses.

`make link-ncursesw` will now link to ncursesw rather than ncurses.
Required a bit of minor macro magic in ll.rs to avoid duplicating everything.
