### PR TITLE
Update to latest master (libc moved)

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -10,7 +10,7 @@
       the safe wrappers.
 */
 
-use std::libc::{ c_char, c_int };
+use libc::{ c_char, c_int };
 use super::ll::*;
 
 extern

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,9 @@
 #![feature(macro_rules)]
 #![allow(non_camel_case_types)]
 
-use std::{ str, char, libc, ptr };
+extern crate libc;
+
+use std::{ str, char, ptr };
 use self::ll::*;
 pub use self::constants::*;
 

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -9,7 +9,7 @@ Low-level interface to foreign
 ncurses functions.
  */
 
-use std::libc::{ c_char, c_int, c_short, c_uint, c_void, FILE };
+use libc::{ c_char, c_int, c_short, c_uint, c_void, FILE };
 
 /* Intrinsic types. */
 pub type chtype = c_uint;


### PR DESCRIPTION
# [nolink] doesn't seem to exist any more, getting errors about it. Not sure what replaced it, if it was replaced, so I haven't tried to fix those.
