### PR TITLE
trim_chars no longer takes a reference

### DIFF
--- a/examples/ex_5.rs
+++ b/examples/ex_5.rs
@@ -215,7 +215,7 @@ impl Pager
     }
 
     /* Trim the word of all delimiters. */
-    let word = word.trim_chars(&|ch: char|
+    let word = word.trim_chars(|ch: char|
                                { word_limits.contains(&(ch as u8)) });
     if word.len() == 0
     { return 0; }


### PR DESCRIPTION
http://static.rust-lang.org/doc/master/std/str/trait.StrSlice.html#tymethod.trim_chars
