### PR TITLE
Fix `make` in OSX by using `perl` instead of `sed` for a text replace.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ${LIB}: ${LIB_DEPS}
 	@mkdir -p target
 	rustc ${CFG_OPT} --out-dir target ${LIB_SRC}
 	@rustc --no-trans --dep-info target/.ncurses.deps ${LIB_SRC}
-	@sed -i 's/.*: //' target/.ncurses.deps
+	@perl -p -i -e 's/.*: //' target/.ncurses.deps
 
 ${EXAMPLES_BIN}: bin/%: examples/%.rs ${LIB}
 	@mkdir -p bin


### PR DESCRIPTION
According to [1](http://stackoverflow.com/questions/2320564/variations-of-sed-between-osx-and-gnu-linux), there's no easy way to make it work on both BSD and
GNU sed.

---

(I don't know if depending on perl for this is a good idea or not.)
