### PR TITLE
fix compile issues on rust and cargo nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ name = "ncurses"
 version = "5.71.1"
 authors = [ "contact@jeaye.com" ]
 
-[[lib]]
+[lib]
 name = "ncurses"

--- a/src/ncurses.rs
+++ b/src/ncurses.rs
@@ -20,7 +20,7 @@ extern crate libc;
 
 use core::mem;
 use std::{ str, char, ptr };
-use self::ll::*;
+use self::ll::{ chtype, FILE_p, mmask_t };
 pub use self::constants::*;
 
 pub mod ll;


### PR DESCRIPTION
- removed glob import self::ll::\* since this isn't actually required
- rustc version: 0.12.0-pre-nightly (01ec6fab2 2014-08-18 00:46:10 +0000)
- cargo version: 0.0.1-pre-nightly (28457b1 2014-08-19 18:54:07 +0000)
