### PR TITLE
Add support for default_color extensions

### DIFF
--- a/src/ll.rs
+++ b/src/ll.rs
@@ -46,6 +46,7 @@ macro_rules! define_sharedffi(
             pub fn addchstr(_:*const chtype) -> c_int;
             pub fn addnstr(_:*const c_char, _:c_int) -> c_int;
             pub fn addstr(_:*const c_char) -> c_int;
+            pub fn assume_default_colors(_:c_int, _:c_int) -> c_int;
             pub fn attroff(_:NCURSES_ATTR_T) -> c_int;
             pub fn attron(_:NCURSES_ATTR_T) -> c_int;
             pub fn attrset(_:NCURSES_ATTR_T) -> c_int;
@@ -246,6 +247,7 @@ macro_rules! define_sharedffi(
             pub fn ungetch(_:c_int) -> c_int;
             pub fn untouchwin(_:WINDOW) -> c_int;
             pub fn use_env(_:c_int);
+            pub fn use_default_colors() -> c_int;
             pub fn vidattr(_:chtype) -> c_int;
             //  fn vidputs(_:chtype, extern  fn f(c_int) -> c_int) -> c_int;
             //pub fn vidputs(_:chtype, f:*mut c_char) -> c_int;

--- a/src/ncurses.rs
+++ b/src/ncurses.rs
@@ -58,6 +58,10 @@ pub fn addstr(s: &str) -> i32
 { unsafe { ll::addstr(s.to_c_str().as_ptr()) } }
 
 
+pub fn assume_default_colors(fg: i32, bg: i32) -> i32
+{ unsafe { ll::assume_default_colors(fg, bg) } }
+
+
 pub fn attroff(a: i32) -> i32
 { unsafe { ll::attroff(a) } }
 
@@ -1218,6 +1222,10 @@ pub fn untouchwin(w: WINDOW) -> i32
 
 pub fn use_env(f: bool)
 { unsafe { ll::use_env(f as libc::c_int) } }
+
+
+pub fn use_default_colors() -> i32
+{ unsafe { ll::use_default_colors() } }
 
 
 pub fn vidattr(attrs: u32) -> i32


### PR DESCRIPTION
Simple change that adds `use_default_colors` and `assume_default_colors` for programs that need to not draw backgrounds, such as the case where `can_change_colors` returns false and the terminal background does not match COLOR_BLACK.

[Function Reference](http://linux.die.net/man/3/use_default_colors)
