### PR TITLE
Fix warning for lowercase static const

### DIFF
--- a/examples/ex_3.rs
+++ b/examples/ex_3.rs
@@ -29,7 +29,7 @@ fn open_file() -> io::File
   {
     println!("Usage:\n\t{} <rust file>", args[0]);
     println!("Example:\n\t{} examples/ex_3.rs", args[0]);
-    fail!("Exiting");
+    panic!("Exiting");
   }
 
   let reader = File::open(&Path::new(args[1].to_string()));

--- a/examples/ex_5.rs
+++ b/examples/ex_5.rs
@@ -346,7 +346,7 @@ fn open_file() -> io::File
   {
     println!("Usage:\n\t{} <rust file>", args[0]);
     println!("Example:\n\t{} examples/ex_5.rs", args[0]);
-    fail!("Exiting");
+    panic!("Exiting");
   }
 
   let reader = File::open(&Path::new(args[1].to_string()));


### PR DESCRIPTION
The constant 'word_limits' in example 5 generated a warning due to warn(non_upper_case_globals), which is on by default. This is using rustc 0.13.0-nightly (15dd90b64 2014-10-30 00:27:02 +0000)
