### PR TITLE
Updated deprecated raw::from_buf to from_raw_buf

### DIFF
--- a/src/ncurses.rs
+++ b/src/ncurses.rs
@@ -19,7 +19,7 @@ extern crate core;
 extern crate libc;
 
 use core::mem;
-use std::{ string, char, ptr };
+use std::{ char, ptr };
 use self::ll::{ chtype, FILE_p, mmask_t };
 pub use self::constants::*;
 
@@ -565,7 +565,7 @@ pub fn is_syncok(w: WINDOW) -> bool
 
 
 pub fn keyname(c: i32) -> String
-{ unsafe { string::raw::from_buf(ll::keyname(c) as *const u8) } }
+{ unsafe { String::from_raw_buf(ll::keyname(c) as *const u8) } }
 
 
 pub fn keypad(w: WINDOW, bf: bool) -> i32
@@ -581,7 +581,7 @@ pub fn leaveok(w: WINDOW, bf: bool) -> i32
 
 
 pub fn longname() -> String
-{ unsafe { string::raw::from_buf(ll::longname() as *const u8) } }
+{ unsafe { String::from_raw_buf(ll::longname() as *const u8) } }
 
 
 pub fn meta(w: WINDOW, bf: bool) -> i32
@@ -1125,7 +1125,7 @@ pub fn slk_init(fmt: i32) -> i32
 
 
 pub fn slk_label(n: i32) -> String
-{ unsafe { string::raw::from_buf(ll::slk_label(n) as *const u8) } }
+{ unsafe { String::from_raw_buf(ll::slk_label(n) as *const u8) } }
 
 
 pub fn slk_noutrefresh() -> i32
@@ -1177,7 +1177,7 @@ pub fn termattrs() -> u32
 
 
 pub fn termname() -> String
-{ unsafe { string::raw::from_buf(ll::termname() as *const u8) } }
+{ unsafe { String::from_raw_buf(ll::termname() as *const u8) } }
 
 
 pub fn timeout(delay: i32)
@@ -1205,11 +1205,11 @@ pub fn tigetnum(capname: &str) -> i32
 
 
 pub fn tigetstr(capname: &str) -> String
-{ unsafe { { string::raw::from_buf(ll::tigetstr(capname.to_c_str().as_ptr()) as *const u8) } } }
+{ unsafe { { String::from_raw_buf(ll::tigetstr(capname.to_c_str().as_ptr()) as *const u8) } } }
 
 
 pub fn tparm(s: &str) -> String
-{ unsafe { { string::raw::from_buf(ll::tparm(s.to_c_str().as_ptr()) as *const u8) } } }
+{ unsafe { { String::from_raw_buf(ll::tparm(s.to_c_str().as_ptr()) as *const u8) } } }
 
 
 pub fn ungetch(ch: i32) -> i32


### PR DESCRIPTION
The function string::raw::from_buf was deprecated in favor of String::from_raw_buf. I also removed the now unused using for string.

I smoke tested this with this file: https://gist.github.com/pmsanford/00a6bd8ee753387c0222
