### PR TITLE
Fix Makefile for OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CFG_OPT ?= -O
 SED_OPT=-i
 
 ifeq ($(shell uname),Darwin)
-	SED_OPT=-i -e
+	SED_OPT=-i ''
 endif
 
 all: ${LIB} ${EXAMPLES_BIN}


### PR DESCRIPTION
This fixes an issue with the Makefile caused by the version of sed that ships with OSX. It does rely on uname existing, but I think that's fair considering the platforms ncurses itself is available for.
