### PR TITLE
Update Ex 4 for namespaced enum changes

### DIFF
--- a/examples/ex_4.rs
+++ b/examples/ex_4.rs
@@ -30,7 +30,7 @@ fn main()
   noecho();
 
   /* Invisible cursor. */
-  curs_set(CURSOR_INVISIBLE);
+  curs_set(CURSOR_VISIBILITY::CURSOR_INVISIBLE);
 
   /* Status/help info. */
   printw("Use the arrow keys to move");


### PR DESCRIPTION
Enum struct variants are now namespaced under the enum name rather than the enclosing module name. Ex_4 wouldn't build without this change.
