### PR TITLE
Fix warnings for unimplemented Copy traits

### DIFF
--- a/src/ll.rs
+++ b/src/ll.rs
@@ -32,10 +32,13 @@ pub type va_list = *mut u8;
 
 /* Custom Types. */
 #[repr(C)]
+#[deriving(Copy)]
 pub struct WINDOW_impl;
 #[repr(C)]
+#[deriving(Copy)]
 pub struct SCREEN_impl;
 #[repr(C)]
+#[deriving(Copy)]
 pub struct MEVENT { id: c_short, x: c_int, y: c_int, z: c_int, bstate: mmask_t}
 
 macro_rules! define_sharedffi(

--- a/src/ncurses.rs
+++ b/src/ncurses.rs
@@ -26,6 +26,7 @@ pub use self::constants::*;
 pub mod ll;
 pub mod constants;
 
+#[deriving(Copy)]
 pub enum CURSOR_VISIBILITY
 {
   CURSOR_INVISIBLE = 0,


### PR DESCRIPTION
Types that can implement Copy now warn when they don't. Added deriving directives.
