### PR TITLE
use &: in closure passed to trim_chars in ex_5

### DIFF
--- a/examples/ex_5.rs
+++ b/examples/ex_5.rs
@@ -67,10 +67,6 @@ static WORD_LIMITS: &'static [u8] = &
   -1 as u8,
 ];
 
-fn is_limit(c: char) -> bool {
-    return WORD_LIMITS.contains(&(c as u8));
-}
-
 struct Pager
 {
   file_reader: io::File,
@@ -215,7 +211,8 @@ impl Pager
     }
 
     /* Trim the word of all delimiters. */
-    let word = word.trim_chars(is_limit);
+    let word = word.trim_chars(|&: ch: char|
+                               { WORD_LIMITS.contains(&(ch as u8) });
 
     if word.len() == 0
     { return 0; }


### PR DESCRIPTION
ex_5 wouldn't build. I don't know much Rust, but this builds at least.
