### PR TITLE
Fix macro def

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 bin
+Cargo.lock
 .*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "ncurses"
+version = "5.71.1"
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,0 @@
-[root]
-name = "ncurses"
-version = "5.71.1"
-

--- a/examples/ex_1.rs
+++ b/examples/ex_1.rs
@@ -8,8 +8,6 @@
       Simple "Hello, world" example.
 */
 
-#![feature(globs)]
-
 extern crate ncurses;
 
 use ncurses::*;

--- a/examples/ex_2.rs
+++ b/examples/ex_2.rs
@@ -8,8 +8,6 @@
       Basic input and attribute example.
 */
 
-#![feature(globs)]
-
 extern crate ncurses;
 
 use std::char;

--- a/examples/ex_3.rs
+++ b/examples/ex_3.rs
@@ -13,8 +13,6 @@
         ./bin/ex_3 examples/ex_3.rs
 */
 
-#![feature(globs)]
-
 extern crate ncurses;
 
 use std::os;

--- a/examples/ex_4.rs
+++ b/examples/ex_4.rs
@@ -10,8 +10,6 @@
       around the screen.
 */
 
-#![feature(globs)]
-
 extern crate ncurses;
 
 use ncurses::*;

--- a/examples/ex_5.rs
+++ b/examples/ex_5.rs
@@ -14,7 +14,6 @@
         ./bin/ex_5 examples/ex_5.rs
 */
 
-#![feature(globs)]
 #![feature(unsafe_destructor)]
 
 extern crate ncurses;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -183,7 +183,7 @@ pub const KEY_EVENT: i32=	0x19b;		/* We were interrupted by an event */
 pub const KEY_MAX: i32=	0x1ff;		/* Maximum key value is 0633 */
 
 /* Mouse Support */
-macro_rules! ncurses_mouse_mask( ($b: expr $m: expr) => ($m << (($b - 1) * 5)); );
+macro_rules! ncurses_mouse_mask( ($b:expr, $m:expr) => ($m << (($b - 1) * 5)); );
 pub const NCURSES_BUTTON_RELEASED: i32=	0x001;
 pub const NCURSES_BUTTON_PRESSED: i32=		0x002;
 pub const NCURSES_BUTTON_CLICKED: i32=		0x004;
@@ -192,48 +192,48 @@ pub const NCURSES_TRIPLE_CLICKED: i32=		0x010;
 pub const NCURSES_RESERVED_EVENT: i32=		0x020;
 
 /* event masks */
-pub const BUTTON1_RELEASED: i32=	ncurses_mouse_mask!(1 NCURSES_BUTTON_RELEASED);
-pub const BUTTON1_PRESSED: i32=	ncurses_mouse_mask!(1 NCURSES_BUTTON_PRESSED);
-pub const BUTTON1_CLICKED: i32=	ncurses_mouse_mask!(1 NCURSES_BUTTON_CLICKED);
-pub const BUTTON1_DOUBLE_CLICKED: i32=	ncurses_mouse_mask!(1 NCURSES_DOUBLE_CLICKED);
-pub const BUTTON1_TRIPLE_CLICKED: i32=	ncurses_mouse_mask!(1 NCURSES_TRIPLE_CLICKED);
+pub const BUTTON1_RELEASED: i32=	ncurses_mouse_mask!(1, NCURSES_BUTTON_RELEASED);
+pub const BUTTON1_PRESSED: i32=	ncurses_mouse_mask!(1, NCURSES_BUTTON_PRESSED);
+pub const BUTTON1_CLICKED: i32=	ncurses_mouse_mask!(1, NCURSES_BUTTON_CLICKED);
+pub const BUTTON1_DOUBLE_CLICKED: i32=	ncurses_mouse_mask!(1, NCURSES_DOUBLE_CLICKED);
+pub const BUTTON1_TRIPLE_CLICKED: i32=	ncurses_mouse_mask!(1, NCURSES_TRIPLE_CLICKED);
 
-pub const BUTTON2_RELEASED: i32=       ncurses_mouse_mask!(2 NCURSES_BUTTON_RELEASED);
-pub const BUTTON2_PRESSED: i32=        ncurses_mouse_mask!(2 NCURSES_BUTTON_PRESSED);
-pub const BUTTON2_CLICKED: i32=        ncurses_mouse_mask!(2 NCURSES_BUTTON_CLICKED);
-pub const BUTTON2_DOUBLE_CLICKED: i32= ncurses_mouse_mask!(2 NCURSES_DOUBLE_CLICKED);
-pub const BUTTON2_TRIPLE_CLICKED: i32= ncurses_mouse_mask!(2 NCURSES_TRIPLE_CLICKED);
+pub const BUTTON2_RELEASED: i32=       ncurses_mouse_mask!(2, NCURSES_BUTTON_RELEASED);
+pub const BUTTON2_PRESSED: i32=        ncurses_mouse_mask!(2, NCURSES_BUTTON_PRESSED);
+pub const BUTTON2_CLICKED: i32=        ncurses_mouse_mask!(2, NCURSES_BUTTON_CLICKED);
+pub const BUTTON2_DOUBLE_CLICKED: i32= ncurses_mouse_mask!(2, NCURSES_DOUBLE_CLICKED);
+pub const BUTTON2_TRIPLE_CLICKED: i32= ncurses_mouse_mask!(2, NCURSES_TRIPLE_CLICKED);
 
-pub const BUTTON3_RELEASED: i32=       ncurses_mouse_mask!(3 NCURSES_BUTTON_RELEASED);
-pub const BUTTON3_PRESSED: i32=        ncurses_mouse_mask!(3 NCURSES_BUTTON_PRESSED);
-pub const BUTTON3_CLICKED: i32=        ncurses_mouse_mask!(3 NCURSES_BUTTON_CLICKED);
-pub const BUTTON3_DOUBLE_CLICKED: i32= ncurses_mouse_mask!(3 NCURSES_DOUBLE_CLICKED);
-pub const BUTTON3_TRIPLE_CLICKED: i32= ncurses_mouse_mask!(3 NCURSES_TRIPLE_CLICKED);
+pub const BUTTON3_RELEASED: i32=       ncurses_mouse_mask!(3, NCURSES_BUTTON_RELEASED);
+pub const BUTTON3_PRESSED: i32=        ncurses_mouse_mask!(3, NCURSES_BUTTON_PRESSED);
+pub const BUTTON3_CLICKED: i32=        ncurses_mouse_mask!(3, NCURSES_BUTTON_CLICKED);
+pub const BUTTON3_DOUBLE_CLICKED: i32= ncurses_mouse_mask!(3, NCURSES_DOUBLE_CLICKED);
+pub const BUTTON3_TRIPLE_CLICKED: i32= ncurses_mouse_mask!(3, NCURSES_TRIPLE_CLICKED);
 
-pub const BUTTON4_RELEASED: i32=       ncurses_mouse_mask!(4 NCURSES_BUTTON_RELEASED);
-pub const BUTTON4_PRESSED: i32=        ncurses_mouse_mask!(4 NCURSES_BUTTON_PRESSED);
-pub const BUTTON4_CLICKED: i32=        ncurses_mouse_mask!(4 NCURSES_BUTTON_CLICKED);
-pub const BUTTON4_DOUBLE_CLICKED: i32= ncurses_mouse_mask!(4 NCURSES_DOUBLE_CLICKED);
-pub const BUTTON4_TRIPLE_CLICKED: i32= ncurses_mouse_mask!(4 NCURSES_TRIPLE_CLICKED);
+pub const BUTTON4_RELEASED: i32=       ncurses_mouse_mask!(4, NCURSES_BUTTON_RELEASED);
+pub const BUTTON4_PRESSED: i32=        ncurses_mouse_mask!(4, NCURSES_BUTTON_PRESSED);
+pub const BUTTON4_CLICKED: i32=        ncurses_mouse_mask!(4, NCURSES_BUTTON_CLICKED);
+pub const BUTTON4_DOUBLE_CLICKED: i32= ncurses_mouse_mask!(4, NCURSES_DOUBLE_CLICKED);
+pub const BUTTON4_TRIPLE_CLICKED: i32= ncurses_mouse_mask!(4, NCURSES_TRIPLE_CLICKED);
 
-pub const BUTTON5_RELEASED: i32=       ncurses_mouse_mask!(5 NCURSES_BUTTON_RELEASED);
-pub const BUTTON5_PRESSED: i32=        ncurses_mouse_mask!(5 NCURSES_BUTTON_PRESSED);
-pub const BUTTON5_CLICKED: i32=        ncurses_mouse_mask!(5 NCURSES_BUTTON_CLICKED);
-pub const BUTTON5_DOUBLE_CLICKED: i32= ncurses_mouse_mask!(5 NCURSES_DOUBLE_CLICKED);
-pub const BUTTON5_TRIPLE_CLICKED: i32= ncurses_mouse_mask!(5 NCURSES_TRIPLE_CLICKED);
+pub const BUTTON5_RELEASED: i32=       ncurses_mouse_mask!(5, NCURSES_BUTTON_RELEASED);
+pub const BUTTON5_PRESSED: i32=        ncurses_mouse_mask!(5, NCURSES_BUTTON_PRESSED);
+pub const BUTTON5_CLICKED: i32=        ncurses_mouse_mask!(5, NCURSES_BUTTON_CLICKED);
+pub const BUTTON5_DOUBLE_CLICKED: i32= ncurses_mouse_mask!(5, NCURSES_DOUBLE_CLICKED);
+pub const BUTTON5_TRIPLE_CLICKED: i32= ncurses_mouse_mask!(5, NCURSES_TRIPLE_CLICKED);
 
-pub const BUTTON_CTRL: i32=		ncurses_mouse_mask!(6 0x001);
-pub const BUTTON_SHIFT: i32=		ncurses_mouse_mask!(6 0x002);
-pub const BUTTON_ALT: i32=		ncurses_mouse_mask!(6 0x004);
-pub const REPORT_MOUSE_POSITION: i32=	ncurses_mouse_mask!(6 0x008);
+pub const BUTTON_CTRL: i32=		ncurses_mouse_mask!(6, 0x001);
+pub const BUTTON_SHIFT: i32=		ncurses_mouse_mask!(6, 0x002);
+pub const BUTTON_ALT: i32=		ncurses_mouse_mask!(6, 0x004);
+pub const REPORT_MOUSE_POSITION: i32=	ncurses_mouse_mask!(6, 0x008);
 
 pub const ALL_MOUSE_EVENTS: i32=	REPORT_MOUSE_POSITION - 1;
 
 /* macros to extract single event-bits from masks */
-macro_rules! button_release( ($e: expr $x: expr) => (e & ncurses_mouse_mask!(x 0x001)); );
-macro_rules! button_press( ($e: expr $x: expr) => (e & ncurses_mouse_mask!(x 0x002)); );
-macro_rules! button_click( ($e: expr $x: expr) => (e & ncurses_mouse_mask!(x 0x004)); );
-macro_rules! button_double_click( ($e: expr $x: expr) => (e & ncurses_mouse_mask!(x 0x008)); );
-macro_rules! button_triple_click( ($e: expr $x: expr) => (e & ncurses_mouse_mask!(x 0x010)); );
-macro_rules! button_reserved_event( ($e: expr $x: expr) => (e & ncurses_mouse_mask!(x 0x020)); );
+macro_rules! button_release( ($e: expr, $x: expr) => (e & ncurses_mouse_mask!(x, 0x001)); );
+macro_rules! button_press( ($e: expr, $x: expr) => (e & ncurses_mouse_mask!(x, 0x002)); );
+macro_rules! button_click( ($e: expr, $x: expr) => (e & ncurses_mouse_mask!(x, 0x004)); );
+macro_rules! button_double_click( ($e: expr, $x: expr) => (e & ncurses_mouse_mask!(x, 0x008)); );
+macro_rules! button_triple_click( ($e: expr, $x: expr) => (e & ncurses_mouse_mask!(x, 0x010)); );
+macro_rules! button_reserved_event( ($e: expr, $x: expr) => (e & ncurses_mouse_mask!(x, 0x020)); );
 

--- a/src/ncurses.rs
+++ b/src/ncurses.rs
@@ -34,7 +34,7 @@ impl FromCStr for String {
         unsafe {
             let len = libc::funcs::c95::string::strlen(s);
             let buf = Vec::from_raw_buf(s, len as usize);
-            String::from_utf8_unchecked(std::mem::transmute(buf))
+            String::from_utf8_unchecked(mem::transmute(buf))
         }
     }
 }

--- a/src/ncurses.rs
+++ b/src/ncurses.rs
@@ -18,7 +18,7 @@ extern crate libc;
 
 use core::mem;
 use std::{ char, ptr };
-use std::ffi::CString;
+use std::ffi::{CString, c_str_to_bytes};
 use self::ll::{ chtype, FILE_p, mmask_t };
 pub use self::constants::*;
 
@@ -32,9 +32,8 @@ trait FromCStr {
 impl FromCStr for String {
     fn from_c_str(s: *const libc::c_char) -> String {
         unsafe {
-            let len = libc::funcs::c95::string::strlen(s);
-            let buf = Vec::from_raw_buf(s, len as usize);
-            String::from_utf8_unchecked(mem::transmute(buf))
+            let bytes = c_str_to_bytes(&s);
+            String::from_utf8_unchecked(bytes.to_vec())
         }
     }
 }


### PR DESCRIPTION
Fixes:

* Macro arguments are not allowed to have 2 `expr` designators next to eachother without a seperating character (I replaced the space with a `,`).
* `int` -> `isize`, `uint` -> `usize` (not needed, but we might as well change it now).
* Changes in the `ffi` module.

PS: I'm new to git, so if I did anything wrong, please tell me :smile: 