### PR TITLE
Fix build for rustc nightly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LIB_DEPS = $(shell head -n1 target/.ncurses.deps 2> /dev/null)
 EXAMPLES_SRC = $(wildcard examples/*.rs)
 
 # Objects
-LIB = target/$(shell rustc --print-file-name ${LIB_SRC})
+LIB = target/$(shell rustc --print file-names ${LIB_SRC})
 EXAMPLES_BIN = $(EXAMPLES_SRC:examples/%.rs=bin/%)
 
 # CFG Directive Options
@@ -26,7 +26,7 @@ link-ncursesw: all
 ${LIB}: ${LIB_DEPS}
 	@mkdir -p target
 	rustc ${CFG_OPT} --out-dir target ${LIB_SRC}
-	@rustc --no-trans --dep-info target/.ncurses.deps ${LIB_SRC}
+	@rustc --emit dep-info target/.ncurses.deps ${LIB_SRC}
 	@sed ${SED_OPT} 's/.*: //' target/.ncurses.deps
 
 ${EXAMPLES_BIN}: bin/%: examples/%.rs ${LIB}


### PR DESCRIPTION
Some argument names in rustc nightly seem to have been changed.