### PR TITLE
Changed 'std::io' -> 'std::old_io' in examples.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ install:
   - tar xf rust-nightly-x86_64-unknown-linux-gnu.tar.gz
   - sudo rust-nightly-x86_64-unknown-linux-gnu/install.sh
 script:
-  - make
+  - cargo build

--- a/examples/ex_3.rs
+++ b/examples/ex_3.rs
@@ -16,11 +16,11 @@
 extern crate ncurses;
 
 use std::os;
-use std::io;
-use std::io::File;
+use std::old_io;
+use std::old_io::File;
 use ncurses::*;
 
-fn open_file() -> io::File
+fn open_file() -> old_io::File
 {
   let args = os::args();
   if args.len() != 2

--- a/examples/ex_5.rs
+++ b/examples/ex_5.rs
@@ -19,8 +19,8 @@
 extern crate ncurses;
 
 use std::{ char, os };
-use std::io;
-use std::io::File;
+use std::old_io;
+use std::old_io::File;
 use ncurses::*;
 
 /* Individual color handles. */
@@ -68,7 +68,7 @@ static WORD_LIMITS: &'static [u8] = &
 
 struct Pager
 {
-  file_reader: io::File,
+  file_reader: old_io::File,
 
   in_comment: bool,
   in_string: bool,
@@ -339,7 +339,7 @@ fn prompt()
   attroff(A_BOLD());
 }
 
-fn open_file() -> io::File
+fn open_file() -> old_io::File
 {
   let args = os::args();
   if args.len() != 2


### PR DESCRIPTION
This change is necessary for the examples to build since io was renamed to old_io.