### PR TITLE
update cargo.toml for crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,14 @@
 name = "ncurses"
 version = "5.71.1"
 authors = [ "contact@jeaye.com" ]
+description = "This is a very thin wrapper around the ncurses TUI lib."
+documentation = "https://github.com/jeaye/ncurses-rs"
+homepage = "https://github.com/jeaye/ncurses-rs"
+repository = "https://github.com/jeaye/ncurses-rs"
+readme = "README.md"
+keywords = ["ncurses","TUI"]
+license = "X11"
+license-file = "LICENSE"
 
 [features]
 default=["wide"]


### PR DESCRIPTION
I'm relatively new to rust, but I've updated your cargo.toml to be compatible with crates.io, and I've published the most recent version of it after reading your comment in the thread about it your interest in finding someone to do it.

Right now however, it shows my github username as the 'owner' of the crate on crates.io, I would be more than happy to add you as the owner (you just need to link your github account to crates.io and generate a token http://doc.crates.io/crates-io.html#publishing-crates)

I hope I haven't jumped the gun by publishing your library to crates, it's just that there are no other rust ncurses libs around.