### PR TITLE
Add menu support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ libc = "*"
 default=["wide"]
 wide = []
 panel = []
+menu = []
 
 [lib]
 name = "ncurses"

--- a/README.md
+++ b/README.md
@@ -22,4 +22,5 @@ Current examples:
 **2.** [Basic Input & Attributes](https://github.com/jeaye/ncurses-rs/blob/master/examples/ex_2.rs)  
 **3.** [Simple Pager](https://github.com/jeaye/ncurses-rs/blob/master/examples/ex_3.rs)  
 **4.** [Window Movement](https://github.com/jeaye/ncurses-rs/blob/master/examples/ex_4.rs)  
-**5.** [Pager & Syntax Highlighting](https://github.com/jeaye/ncurses-rs/blob/master/examples/ex_5.rs)  
+**5.** [Menu Library](https://github.com/jeaye/ncurses-rs/blob/master/examples/ex_5.rs) (requires rust nightly)  
+**6.** [Pager & Syntax Highlighting](https://github.com/jeaye/ncurses-rs/blob/master/examples/ex_6.rs)  

--- a/examples/ex_5.rs
+++ b/examples/ex_5.rs
@@ -1,352 +1,80 @@
-/*
-    Copyright © 2013 Free Software Foundation, Inc
-    See licensing in LICENSE file
-
-    File: examples/ex_5.rs
-    Author: Jesse 'Jeaye' Wilkerson
-    Description:
-      Extension of ex_3 that adds naive syntax
-      highlighting to showcase attributes.
-
-      Usage:
-        ./bin/ex_5 <rust file>
-      Example:
-        ./bin/ex_5 examples/ex_5.rs
-*/
-
 extern crate ncurses;
 
-use std::{ char, env, fs };
-use std::path::Path;
-use std::io::{Read, Bytes};
-use std::iter::Peekable;
 use ncurses::*;
 
-/* Individual color handles. */
-static COLOR_BACKGROUND: i16 = 16;
-static COLOR_FOREGROUND: i16 = 17;
-static COLOR_KEYWORD: i16 = 18;
-static COLOR_TYPE: i16 = 19;
-static COLOR_STORAGE: i16 = 20;
-static COLOR_COMMENT: i16 = 21;
-static COLOR_STRING: i16 = 22;
-static COLOR_CHAR: i16 = 23;
-static COLOR_NUMBER: i16 = 24;
+fn main() {
+  /* Initialize curses */
+  initscr();
+  start_color();
+  cbreak();
+  noecho();
+  curs_set(CURSOR_VISIBILITY::CURSOR_INVISIBLE);
+  keypad(stdscr, true);
+  init_pair(1, COLOR_RED, COLOR_BLACK);
 
-/* Color pairs; foreground && background. */
-static COLOR_PAIR_DEFAULT: i16 = 1;
-static COLOR_PAIR_KEYWORD: i16 = 2;
-static COLOR_PAIR_TYPE: i16 = 3;
-static COLOR_PAIR_STORAGE: i16 = 4;
-static COLOR_PAIR_COMMENT: i16 = 5;
-static COLOR_PAIR_STRING: i16 = 6;
-static COLOR_PAIR_CHAR: i16 = 7;
-static COLOR_PAIR_NUMBER: i16 = 8;
+  /* Create items */
+  let mut items: Vec<ITEM> = Vec::new();
+  items.push(new_item("Choice 1", "Choice 1 description"));
+  items.push(new_item("Choice 2", "Choice 2 description"));
+  items.push(new_item("Choice 3", "Choice 3 description"));
+  items.push(new_item("Choice 4", "Choice 4 description"));
+  items.push(new_item("Exit", "Exit description"));
 
-/* Word delimiters. */
-static WORD_LIMITS: &'static [u8] = &
-[
-  ' ' as u8,
-  '(' as u8,
-  ')' as u8,
-  ':' as u8,
-  ';' as u8,
-  '&' as u8,
-  '+' as u8,
-  '-' as u8,
-  ',' as u8,
-  '.' as u8,
-  '@' as u8,
-  '~' as u8,
-  '\\' as u8,
-  '\n' as u8,
-  '\r' as u8,
-  '\0' as u8,
-  !0 as u8,
-];
+  /* Crate menu */
+  let my_menu = new_menu(&mut items);
+  menu_opts_off(my_menu, O_SHOWDESC);
 
-struct Pager
-{
-  file_reader: Peekable<Bytes<fs::File>>,
+  let my_menu_win = newwin(9, 18, 4, 4);
+  keypad(my_menu_win, true);
 
-  in_comment: bool,
-  in_string: bool,
-  in_char: bool,
+  /* Set main window and sub window */
+  set_menu_win(my_menu, my_menu_win);
+  set_menu_sub(my_menu, derwin(my_menu_win, 5, 0, 2, 2));
 
-  screen_width: i32,
-  screen_height: i32,
-  curr_x: i32,
-  curr_y: i32,
-}
+  /* Set menu mark to the string " * " */
+  set_menu_mark(my_menu, " * ");
 
-impl Pager
-{
-  pub fn new() -> Pager
+  /* Print a border around the main window */
+  box_(my_menu_win, 0, 0);
+  mvprintw(LINES - 3, 0, "Press <ENTER> to see the option selected");
+  mvprintw(LINES - 2, 0, "F1 to exit");
+  refresh();
+
+  /* Post the menu */
+  post_menu(my_menu);
+  wrefresh(my_menu_win);
+
+  let mut ch = getch();
+  while ch != KEY_F(1)
   {
-    Pager
+    match ch
     {
-      file_reader: open_file().bytes().peekable(),
-
-      in_comment: false,
-      in_string: false,
-      in_char: false,
-
-      screen_width: 0,
-      screen_height: 0,
-      curr_x: 0,
-      curr_y: 0,
+      KEY_UP => {
+        menu_driver(my_menu, REQ_UP_ITEM);
+      },
+      KEY_DOWN => {
+        menu_driver(my_menu, REQ_DOWN_ITEM);
+      },
+      10 => {/* Enter */
+        mv(20, 0);
+        clrtoeol();
+        mvprintw(20, 0, &format!("Item selected is : {}", item_name(current_item(my_menu)))[..]);
+        pos_menu_cursor(my_menu);
+      },
+      _ => {}
     }
+    wrefresh(my_menu_win);
+    ch = getch();
   }
 
-  pub fn initialize(&mut self)
-  {
-    /* Start ncurses. */
-    initscr();
-    keypad(stdscr, true);
-    noecho();
+  unpost_menu(my_menu);
 
-    /* Start colors. */
-    start_color();
-    init_color(COLOR_BACKGROUND, 0, 43 * 4, 54 * 4);
-    init_color(COLOR_FOREGROUND, 142 * 4, 161 * 4, 161 * 4);
-    init_color(COLOR_KEYWORD, 130 * 4, 151 * 4, 0);
-    init_color(COLOR_TYPE, 197 * 4, 73 * 4, 27 * 4);
-    init_color(COLOR_STORAGE, 219 * 4, 51 * 4, 47 * 4);
-    init_color(COLOR_COMMENT, 33 * 4, 138 * 4, 206 * 4);
-    init_color(COLOR_STRING, 34 * 4, 154 * 4, 142 * 4);
-    init_color(COLOR_CHAR, 34 * 4, 154 * 4, 142 * 4);
-    init_color(COLOR_NUMBER, 236 * 4, 107 * 4, 83 * 4);
-
-    init_pair(COLOR_PAIR_DEFAULT, COLOR_FOREGROUND, COLOR_BACKGROUND);
-    init_pair(COLOR_PAIR_KEYWORD, COLOR_KEYWORD, COLOR_BACKGROUND);
-    init_pair(COLOR_PAIR_TYPE, COLOR_TYPE, COLOR_BACKGROUND);
-    init_pair(COLOR_PAIR_STORAGE, COLOR_STORAGE, COLOR_BACKGROUND);
-    init_pair(COLOR_PAIR_COMMENT, COLOR_COMMENT, COLOR_BACKGROUND);
-    init_pair(COLOR_PAIR_STRING, COLOR_STRING, COLOR_BACKGROUND);
-    init_pair(COLOR_PAIR_CHAR, COLOR_CHAR, COLOR_BACKGROUND);
-    init_pair(COLOR_PAIR_NUMBER, COLOR_NUMBER, COLOR_BACKGROUND);
-
-    /* Set the window's background color. */
-    bkgd(' ' as chtype | COLOR_PAIR(COLOR_PAIR_DEFAULT) as chtype);
-
-    /* Get the screen bounds. */
-    getmaxyx(stdscr, &mut self.screen_height, &mut self.screen_width);
+  /* free items */
+  for &item in items.iter() {
+    free_item(item);
   }
 
-  /* Returns the word and delimiter following it. */
-  pub fn read_word(&mut self) -> (String, char)
-  {
-    let mut s: Vec<u8> = vec![];
-    let mut ch : u8 = self.file_reader.next().unwrap().ok().expect("Unable to read byte");
+  free_menu(my_menu);
 
-    /* Read until we hit a word delimiter. */
-    while !WORD_LIMITS.contains(&ch)
-    {
-      s.push(ch);
-      ch = self.file_reader.next().unwrap().ok().expect("Unable to read byte");
-    }
-
-    /* Return the word string and the terminating delimiter. */
-    match char::from_u32(ch as u32)
-    {
-      Some(ch) => (String::from_utf8(s).ok().expect("utf-8 conversion failed"), ch),
-      None => (String::from_utf8(s).ok().expect("utf-8 conversion failed"), ' '),
-    }
-  }
-
-  /* Retuns the attribute the given word requires. */
-  pub fn highlight_word(&mut self, word: &str) -> attr_t
-  {
-    /* Comments. */
-    if self.in_comment && !word.contains("*/")
-    { return COLOR_PAIR(COLOR_PAIR_COMMENT); }
-    else if self.in_comment && word.contains("*/")
-    {
-      self.in_comment = false;
-      return COLOR_PAIR(COLOR_PAIR_COMMENT);
-    }
-    else if !self.in_comment && word.contains("/*")
-    {
-      self.in_comment = true;
-      return COLOR_PAIR(COLOR_PAIR_COMMENT);
-    }
-
-    /* Strings. */
-    if !self.in_char
-    {
-      if self.in_string && !word.contains("\"")
-      { return COLOR_PAIR(COLOR_PAIR_STRING); }
-      else if self.in_string && word.contains("\"")
-      {
-        self.in_string = false;
-        return COLOR_PAIR(COLOR_PAIR_STRING);
-      }
-      else if !self.in_string && word.contains("\"")
-      {
-        /* If the same quote is found from either direction
-         * then it's the only quote in the string. */
-        if word.find('\"') == word.rfind('\"')
-        { self.in_string = true; }
-        return COLOR_PAIR(COLOR_PAIR_STRING);
-      }
-    }
-
-    /* Chars. */
-    if self.in_char && !word.contains("\'")
-    { return COLOR_PAIR(COLOR_PAIR_CHAR); }
-    else if self.in_char && word.contains("\'")
-    {
-      self.in_char = false;
-      return COLOR_PAIR(COLOR_PAIR_CHAR);
-    }
-    else if !self.in_char && word.contains("\'") && !word.contains("static")
-    {
-      /* If the same quote is found from either direction
-       * then it's the only quote in the string. */
-      if word.find('\'') == word.rfind('\'')
-      { self.in_char = true; }
-      return COLOR_PAIR(COLOR_PAIR_CHAR);
-    }
-
-    /* Trim the word of all delimiters. */
-    let word = word.trim_matches(|ch: char|
-                                 { WORD_LIMITS.contains(&(ch as u8)) });
-
-    if word.len() == 0
-    { return 0; }
-
-    /* If it starts with a number, it is a number. */
-    if word.as_bytes()[0] >= '0' as u8 && word.as_bytes()[0] <= '9' as u8
-    { return COLOR_PAIR(COLOR_PAIR_NUMBER); }
-
-    match word
-    {
-      /* Key words. */
-      "break" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "continue" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "do" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "else" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "extern" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "in" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "if" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "impl" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "let" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "log" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "loop" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "match" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "once" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "priv" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "pub" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "return" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "unsafe" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "while" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "use" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "mod" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "trait" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "struct" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "enum" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "type" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-      "fn" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
-
-      /* Types. */
-      "int" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
-      "uint" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
-      "char" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
-      "bool" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
-      "u8" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
-      "u16" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
-      "u32" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
-      "u64" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
-      "i16" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
-      "i32" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
-      "i64" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
-      "f32" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
-      "f64" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
-      "str" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
-      "self" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
-      "Self" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
-
-      /* Storage. */
-      "const" => { COLOR_PAIR(COLOR_PAIR_STORAGE) },
-      "mut" => { COLOR_PAIR(COLOR_PAIR_STORAGE) },
-      "ref" => { COLOR_PAIR(COLOR_PAIR_STORAGE) },
-      "static" => { COLOR_PAIR(COLOR_PAIR_STORAGE) },
-
-      /* Not something we need to highlight. */
-      _ => 0,
-    }
-  }
-
-}
-
-impl Drop for Pager
-{
-  fn drop(&mut self)
-  {
-    /* Final prompt before closing. */
-    mv(self.screen_height - 1, 0);
-    prompt();
-    endwin();
-  }
-}
-
-fn main()
-{
-  let mut pager = Pager::new();
-  pager.initialize();
-
-  /* Read the whole file. */
-  while pager.file_reader.peek().is_some()
-  {
-    /* Read a word at a time. */
-    let (word, leftover) = pager.read_word();
-    let attr = pager.highlight_word(word.as_ref());
-    let leftover_attr = pager.highlight_word(format!("{}", leftover).as_ref());
-
-    /* Get the current position on the screen. */
-    getyx(stdscr, &mut pager.curr_y, &mut pager.curr_x);
-
-    if pager.curr_y == (pager.screen_height - 1)
-    {
-      /* Status bar at the bottom. */
-      prompt();
-
-      /* Once a key is pressed, clear the screen and continue. */
-      clear();
-      mv(0, 0);
-    }
-    else
-    {
-      attron(attr);
-      printw(word.as_ref());
-      attroff(attr);
-
-      attron(leftover_attr);
-      addch(leftover as chtype);
-      attroff(leftover_attr);
-    }
-  }
-}
-
-fn prompt()
-{
-  attron(A_BOLD());
-  printw("<-Press Space->");
-  while getch() != ' ' as i32
-  { }
-  attroff(A_BOLD());
-}
-
-fn open_file() -> fs::File
-{
-  let args : Vec<_> = env::args().collect();
-  if args.len() != 2
-  {
-    println!("Usage:\n\t{} <rust file>", args[0]);
-    println!("Example:\n\t{} examples/ex_5.rs", args[0]);
-    panic!("Exiting");
-  }
-
-  let reader = fs::File::open(Path::new(&args[1]));
-  reader.ok().expect("Unable to open file")
+  endwin();
 }

--- a/examples/ex_6.rs
+++ b/examples/ex_6.rs
@@ -1,0 +1,80 @@
+extern crate ncurses;
+
+use ncurses::*;
+
+fn main() {
+  /* Initialize curses */
+  initscr();
+  start_color();
+  cbreak();
+  noecho();
+  curs_set(CURSOR_VISIBILITY::CURSOR_INVISIBLE);
+  keypad(stdscr, true);
+  init_pair(1, COLOR_RED, COLOR_BLACK);
+
+  /* Create items */
+  let mut items: Vec<ITEM> = Vec::new();
+  items.push(new_item("Choice 1", "Choice 1 description"));
+  items.push(new_item("Choice 2", "Choice 2 description"));
+  items.push(new_item("Choice 3", "Choice 3 description"));
+  items.push(new_item("Choice 4", "Choice 4 description"));
+  items.push(new_item("Exit", "Exit description"));
+
+  /* Crate menu */
+  let my_menu = new_menu(&mut items);
+  menu_opts_off(my_menu, O_SHOWDESC);
+
+  let my_menu_win = newwin(9, 18, 4, 4);
+  keypad(my_menu_win, true);
+
+  /* Set main window and sub window */
+  set_menu_win(my_menu, my_menu_win);
+  set_menu_sub(my_menu, derwin(my_menu_win, 5, 0, 2, 2));
+
+  /* Set menu mark to the string " * " */
+  set_menu_mark(my_menu, " * ");
+
+  /* Print a border around the main window */
+  box_(my_menu_win, 0, 0);
+  mvprintw(LINES - 3, 0, "Press <ENTER> to see the option selected");
+  mvprintw(LINES - 2, 0, "F1 to exit");
+  refresh();
+
+  /* Post the menu */
+  post_menu(my_menu);
+  wrefresh(my_menu_win);
+
+  let mut ch = getch();
+  while ch != KEY_F(1)
+  {
+    match ch
+    {
+      KEY_UP => {
+        menu_driver(my_menu, REQ_UP_ITEM);
+      },
+      KEY_DOWN => {
+        menu_driver(my_menu, REQ_DOWN_ITEM);
+      },
+      10 => {/* Enter */
+        mv(20, 0);
+        clrtoeol();
+        mvprintw(20, 0, &format!("Item selected is : {}", item_name(current_item(my_menu)))[..]);
+        pos_menu_cursor(my_menu);
+      },
+      _ => {}
+    }
+    wrefresh(my_menu_win);
+    ch = getch();
+  }
+
+  unpost_menu(my_menu);
+
+  /* free items */
+  for &item in items.iter() {
+    free_item(item);
+  }
+
+  free_menu(my_menu);
+
+  endwin();
+}

--- a/examples/ex_6.rs
+++ b/examples/ex_6.rs
@@ -1,80 +1,352 @@
+/*
+    Copyright © 2013 Free Software Foundation, Inc
+    See licensing in LICENSE file
+
+    File: examples/ex_6.rs
+    Author: Jesse 'Jeaye' Wilkerson
+    Description:
+      Extension of ex_3 that adds naive syntax
+      highlighting to showcase attributes.
+
+      Usage:
+        ./bin/ex_6 <rust file>
+      Example:
+        ./bin/ex_6 examples/ex_6.rs
+*/
+
 extern crate ncurses;
 
+use std::{ char, env, fs };
+use std::path::Path;
+use std::io::{Read, Bytes};
+use std::iter::Peekable;
 use ncurses::*;
 
-fn main() {
-  /* Initialize curses */
-  initscr();
-  start_color();
-  cbreak();
-  noecho();
-  curs_set(CURSOR_VISIBILITY::CURSOR_INVISIBLE);
-  keypad(stdscr, true);
-  init_pair(1, COLOR_RED, COLOR_BLACK);
+/* Individual color handles. */
+static COLOR_BACKGROUND: i16 = 16;
+static COLOR_FOREGROUND: i16 = 17;
+static COLOR_KEYWORD: i16 = 18;
+static COLOR_TYPE: i16 = 19;
+static COLOR_STORAGE: i16 = 20;
+static COLOR_COMMENT: i16 = 21;
+static COLOR_STRING: i16 = 22;
+static COLOR_CHAR: i16 = 23;
+static COLOR_NUMBER: i16 = 24;
 
-  /* Create items */
-  let mut items: Vec<ITEM> = Vec::new();
-  items.push(new_item("Choice 1", "Choice 1 description"));
-  items.push(new_item("Choice 2", "Choice 2 description"));
-  items.push(new_item("Choice 3", "Choice 3 description"));
-  items.push(new_item("Choice 4", "Choice 4 description"));
-  items.push(new_item("Exit", "Exit description"));
+/* Color pairs; foreground && background. */
+static COLOR_PAIR_DEFAULT: i16 = 1;
+static COLOR_PAIR_KEYWORD: i16 = 2;
+static COLOR_PAIR_TYPE: i16 = 3;
+static COLOR_PAIR_STORAGE: i16 = 4;
+static COLOR_PAIR_COMMENT: i16 = 5;
+static COLOR_PAIR_STRING: i16 = 6;
+static COLOR_PAIR_CHAR: i16 = 7;
+static COLOR_PAIR_NUMBER: i16 = 8;
 
-  /* Crate menu */
-  let my_menu = new_menu(&mut items);
-  menu_opts_off(my_menu, O_SHOWDESC);
+/* Word delimiters. */
+static WORD_LIMITS: &'static [u8] = &
+[
+  ' ' as u8,
+  '(' as u8,
+  ')' as u8,
+  ':' as u8,
+  ';' as u8,
+  '&' as u8,
+  '+' as u8,
+  '-' as u8,
+  ',' as u8,
+  '.' as u8,
+  '@' as u8,
+  '~' as u8,
+  '\\' as u8,
+  '\n' as u8,
+  '\r' as u8,
+  '\0' as u8,
+  !0 as u8,
+];
 
-  let my_menu_win = newwin(9, 18, 4, 4);
-  keypad(my_menu_win, true);
+struct Pager
+{
+  file_reader: Peekable<Bytes<fs::File>>,
 
-  /* Set main window and sub window */
-  set_menu_win(my_menu, my_menu_win);
-  set_menu_sub(my_menu, derwin(my_menu_win, 5, 0, 2, 2));
+  in_comment: bool,
+  in_string: bool,
+  in_char: bool,
 
-  /* Set menu mark to the string " * " */
-  set_menu_mark(my_menu, " * ");
+  screen_width: i32,
+  screen_height: i32,
+  curr_x: i32,
+  curr_y: i32,
+}
 
-  /* Print a border around the main window */
-  box_(my_menu_win, 0, 0);
-  mvprintw(LINES - 3, 0, "Press <ENTER> to see the option selected");
-  mvprintw(LINES - 2, 0, "F1 to exit");
-  refresh();
-
-  /* Post the menu */
-  post_menu(my_menu);
-  wrefresh(my_menu_win);
-
-  let mut ch = getch();
-  while ch != KEY_F(1)
+impl Pager
+{
+  pub fn new() -> Pager
   {
-    match ch
+    Pager
     {
-      KEY_UP => {
-        menu_driver(my_menu, REQ_UP_ITEM);
-      },
-      KEY_DOWN => {
-        menu_driver(my_menu, REQ_DOWN_ITEM);
-      },
-      10 => {/* Enter */
-        mv(20, 0);
-        clrtoeol();
-        mvprintw(20, 0, &format!("Item selected is : {}", item_name(current_item(my_menu)))[..]);
-        pos_menu_cursor(my_menu);
-      },
-      _ => {}
+      file_reader: open_file().bytes().peekable(),
+
+      in_comment: false,
+      in_string: false,
+      in_char: false,
+
+      screen_width: 0,
+      screen_height: 0,
+      curr_x: 0,
+      curr_y: 0,
     }
-    wrefresh(my_menu_win);
-    ch = getch();
   }
 
-  unpost_menu(my_menu);
+  pub fn initialize(&mut self)
+  {
+    /* Start ncurses. */
+    initscr();
+    keypad(stdscr, true);
+    noecho();
 
-  /* free items */
-  for &item in items.iter() {
-    free_item(item);
+    /* Start colors. */
+    start_color();
+    init_color(COLOR_BACKGROUND, 0, 43 * 4, 54 * 4);
+    init_color(COLOR_FOREGROUND, 142 * 4, 161 * 4, 161 * 4);
+    init_color(COLOR_KEYWORD, 130 * 4, 151 * 4, 0);
+    init_color(COLOR_TYPE, 197 * 4, 73 * 4, 27 * 4);
+    init_color(COLOR_STORAGE, 219 * 4, 51 * 4, 47 * 4);
+    init_color(COLOR_COMMENT, 33 * 4, 138 * 4, 206 * 4);
+    init_color(COLOR_STRING, 34 * 4, 154 * 4, 142 * 4);
+    init_color(COLOR_CHAR, 34 * 4, 154 * 4, 142 * 4);
+    init_color(COLOR_NUMBER, 236 * 4, 107 * 4, 83 * 4);
+
+    init_pair(COLOR_PAIR_DEFAULT, COLOR_FOREGROUND, COLOR_BACKGROUND);
+    init_pair(COLOR_PAIR_KEYWORD, COLOR_KEYWORD, COLOR_BACKGROUND);
+    init_pair(COLOR_PAIR_TYPE, COLOR_TYPE, COLOR_BACKGROUND);
+    init_pair(COLOR_PAIR_STORAGE, COLOR_STORAGE, COLOR_BACKGROUND);
+    init_pair(COLOR_PAIR_COMMENT, COLOR_COMMENT, COLOR_BACKGROUND);
+    init_pair(COLOR_PAIR_STRING, COLOR_STRING, COLOR_BACKGROUND);
+    init_pair(COLOR_PAIR_CHAR, COLOR_CHAR, COLOR_BACKGROUND);
+    init_pair(COLOR_PAIR_NUMBER, COLOR_NUMBER, COLOR_BACKGROUND);
+
+    /* Set the window's background color. */
+    bkgd(' ' as chtype | COLOR_PAIR(COLOR_PAIR_DEFAULT) as chtype);
+
+    /* Get the screen bounds. */
+    getmaxyx(stdscr, &mut self.screen_height, &mut self.screen_width);
   }
 
-  free_menu(my_menu);
+  /* Returns the word and delimiter following it. */
+  pub fn read_word(&mut self) -> (String, char)
+  {
+    let mut s: Vec<u8> = vec![];
+    let mut ch : u8 = self.file_reader.next().unwrap().ok().expect("Unable to read byte");
 
-  endwin();
+    /* Read until we hit a word delimiter. */
+    while !WORD_LIMITS.contains(&ch)
+    {
+      s.push(ch);
+      ch = self.file_reader.next().unwrap().ok().expect("Unable to read byte");
+    }
+
+    /* Return the word string and the terminating delimiter. */
+    match char::from_u32(ch as u32)
+    {
+      Some(ch) => (String::from_utf8(s).ok().expect("utf-8 conversion failed"), ch),
+      None => (String::from_utf8(s).ok().expect("utf-8 conversion failed"), ' '),
+    }
+  }
+
+  /* Retuns the attribute the given word requires. */
+  pub fn highlight_word(&mut self, word: &str) -> attr_t
+  {
+    /* Comments. */
+    if self.in_comment && !word.contains("*/")
+    { return COLOR_PAIR(COLOR_PAIR_COMMENT); }
+    else if self.in_comment && word.contains("*/")
+    {
+      self.in_comment = false;
+      return COLOR_PAIR(COLOR_PAIR_COMMENT);
+    }
+    else if !self.in_comment && word.contains("/*")
+    {
+      self.in_comment = true;
+      return COLOR_PAIR(COLOR_PAIR_COMMENT);
+    }
+
+    /* Strings. */
+    if !self.in_char
+    {
+      if self.in_string && !word.contains("\"")
+      { return COLOR_PAIR(COLOR_PAIR_STRING); }
+      else if self.in_string && word.contains("\"")
+      {
+        self.in_string = false;
+        return COLOR_PAIR(COLOR_PAIR_STRING);
+      }
+      else if !self.in_string && word.contains("\"")
+      {
+        /* If the same quote is found from either direction
+         * then it's the only quote in the string. */
+        if word.find('\"') == word.rfind('\"')
+        { self.in_string = true; }
+        return COLOR_PAIR(COLOR_PAIR_STRING);
+      }
+    }
+
+    /* Chars. */
+    if self.in_char && !word.contains("\'")
+    { return COLOR_PAIR(COLOR_PAIR_CHAR); }
+    else if self.in_char && word.contains("\'")
+    {
+      self.in_char = false;
+      return COLOR_PAIR(COLOR_PAIR_CHAR);
+    }
+    else if !self.in_char && word.contains("\'") && !word.contains("static")
+    {
+      /* If the same quote is found from either direction
+       * then it's the only quote in the string. */
+      if word.find('\'') == word.rfind('\'')
+      { self.in_char = true; }
+      return COLOR_PAIR(COLOR_PAIR_CHAR);
+    }
+
+    /* Trim the word of all delimiters. */
+    let word = word.trim_matches(|ch: char|
+                                 { WORD_LIMITS.contains(&(ch as u8)) });
+
+    if word.len() == 0
+    { return 0; }
+
+    /* If it starts with a number, it is a number. */
+    if word.as_bytes()[0] >= '0' as u8 && word.as_bytes()[0] <= '9' as u8
+    { return COLOR_PAIR(COLOR_PAIR_NUMBER); }
+
+    match word
+    {
+      /* Key words. */
+      "break" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "continue" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "do" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "else" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "extern" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "in" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "if" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "impl" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "let" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "log" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "loop" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "match" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "once" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "priv" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "pub" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "return" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "unsafe" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "while" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "use" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "mod" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "trait" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "struct" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "enum" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "type" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+      "fn" => { COLOR_PAIR(COLOR_PAIR_KEYWORD) },
+
+      /* Types. */
+      "int" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
+      "uint" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
+      "char" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
+      "bool" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
+      "u8" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
+      "u16" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
+      "u32" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
+      "u64" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
+      "i16" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
+      "i32" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
+      "i64" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
+      "f32" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
+      "f64" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
+      "str" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
+      "self" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
+      "Self" => { COLOR_PAIR(COLOR_PAIR_TYPE) },
+
+      /* Storage. */
+      "const" => { COLOR_PAIR(COLOR_PAIR_STORAGE) },
+      "mut" => { COLOR_PAIR(COLOR_PAIR_STORAGE) },
+      "ref" => { COLOR_PAIR(COLOR_PAIR_STORAGE) },
+      "static" => { COLOR_PAIR(COLOR_PAIR_STORAGE) },
+
+      /* Not something we need to highlight. */
+      _ => 0,
+    }
+  }
+
+}
+
+impl Drop for Pager
+{
+  fn drop(&mut self)
+  {
+    /* Final prompt before closing. */
+    mv(self.screen_height - 1, 0);
+    prompt();
+    endwin();
+  }
+}
+
+fn main()
+{
+  let mut pager = Pager::new();
+  pager.initialize();
+
+  /* Read the whole file. */
+  while pager.file_reader.peek().is_some()
+  {
+    /* Read a word at a time. */
+    let (word, leftover) = pager.read_word();
+    let attr = pager.highlight_word(word.as_ref());
+    let leftover_attr = pager.highlight_word(format!("{}", leftover).as_ref());
+
+    /* Get the current position on the screen. */
+    getyx(stdscr, &mut pager.curr_y, &mut pager.curr_x);
+
+    if pager.curr_y == (pager.screen_height - 1)
+    {
+      /* Status bar at the bottom. */
+      prompt();
+
+      /* Once a key is pressed, clear the screen and continue. */
+      clear();
+      mv(0, 0);
+    }
+    else
+    {
+      attron(attr);
+      printw(word.as_ref());
+      attroff(attr);
+
+      attron(leftover_attr);
+      addch(leftover as chtype);
+      attroff(leftover_attr);
+    }
+  }
+}
+
+fn prompt()
+{
+  attron(A_BOLD());
+  printw("<-Press Space->");
+  while getch() != ' ' as i32
+  { }
+  attroff(A_BOLD());
+}
+
+fn open_file() -> fs::File
+{
+  let args : Vec<_> = env::args().collect();
+  if args.len() != 2
+  {
+    println!("Usage:\n\t{} <rust file>", args[0]);
+    println!("Example:\n\t{} examples/ex_5.rs", args[0]);
+    panic!("Exiting");
+  }
+
+  let reader = fs::File::open(Path::new(&args[1]));
+  reader.ok().expect("Unable to open file")
 }

--- a/src/menu/constants.rs
+++ b/src/menu/constants.rs
@@ -1,0 +1,30 @@
+use constants::KEY_MAX;
+
+pub const O_ONEVALUE: i32 = 0x01;
+pub const O_SHOWDESC: i32 = 0x02;
+pub const O_ROWMAJOR: i32 = 0x04;
+pub const O_IGNORECASE: i32 = 0x08;
+pub const O_SHOWMATCH: i32 = 0x10;
+pub const O_NONCYCLIC: i32 = 0x20;
+pub const O_SELECTABLE: i32 = 0x01;
+
+pub const REQ_LEFT_ITEM: i32 = KEY_MAX + 1;
+pub const REQ_RIGHT_ITEM: i32 = KEY_MAX + 2;
+pub const REQ_UP_ITEM: i32 = KEY_MAX + 3;
+pub const REQ_DOWN_ITEM: i32 = KEY_MAX + 4;
+pub const REQ_SCR_ULINE: i32 = KEY_MAX + 5;
+pub const REQ_SCR_DLINE: i32 = KEY_MAX + 6;
+pub const REQ_SCR_DPAGE: i32 = KEY_MAX + 7;
+pub const REQ_SCR_UPAGE: i32 = KEY_MAX + 8;
+pub const REQ_FIRST_ITEM: i32 = KEY_MAX + 9;
+pub const REQ_LAST_ITEM: i32 = KEY_MAX + 10;
+pub const REQ_NEXT_ITEM: i32 = KEY_MAX + 11;
+pub const REQ_PREV_ITEM: i32 = KEY_MAX + 12;
+pub const REQ_TOGGLE_ITEM: i32 = KEY_MAX + 13;
+pub const REQ_CLEAR_PATTERN: i32 = KEY_MAX + 14;
+pub const REQ_BACK_PATTERN: i32 = KEY_MAX + 15;
+pub const REQ_NEXT_MATCH: i32 = KEY_MAX + 16;
+pub const REQ_PREV_MATCH: i32 = KEY_MAX + 17;
+
+pub const MIN_MENU_COMMAND: i32 = KEY_MAX + 1;
+pub const MAX_MENU_COMMAND: i32 = KEY_MAX + 17;

--- a/src/menu/ll.rs
+++ b/src/menu/ll.rs
@@ -1,0 +1,88 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+use libc::{c_int, c_char, c_void};
+use ll::{WINDOW, chtype};
+
+pub type MENU = *mut MENU_impl;
+pub type ITEM = *mut ITEM_impl;
+pub type HOOK = Option<extern "C" fn(MENU)>;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MENU_impl;
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ITEM_impl;
+
+#[cfg(feature="menu")] #[link(name="menu")]
+extern {
+  pub fn menu_items(_:MENU) -> *mut ITEM;
+  pub fn current_item(_:MENU) -> ITEM;
+  pub fn new_item(_:*const c_char, _:*const c_char) -> ITEM;
+  pub fn new_menu(_:*mut ITEM) -> MENU;
+  pub fn item_opts(_:ITEM) -> c_int;
+  pub fn menu_opts(_:MENU) -> c_int;
+
+  pub fn item_init(_:MENU) -> HOOK;
+  pub fn item_term(_:MENU) -> HOOK;
+  pub fn menu_init(_:MENU) -> HOOK;
+  pub fn menu_term(_:MENU) -> HOOK;
+
+  pub fn menu_sub(_:MENU) -> WINDOW;
+  pub fn menu_win(_:MENU) -> WINDOW;
+
+  pub fn item_description(_:ITEM) -> *const c_char;
+  pub fn item_name(_:ITEM) -> *const c_char;
+  pub fn menu_mark(_:MENU) -> *const c_char;
+  pub fn menu_request_name(_:c_int) -> *const c_char;
+
+  pub fn menu_pattern(_:MENU) -> *mut c_char;
+
+  pub fn menu_back(_:MENU) -> chtype;
+  pub fn menu_fore(_:MENU) -> chtype;
+  pub fn menu_grey(_:MENU) -> chtype;
+
+  pub fn free_item(_:ITEM) -> c_int;
+  pub fn free_menu(_:MENU) -> c_int;
+  pub fn item_count(_:MENU) -> c_int;
+  pub fn item_index(_:ITEM) -> c_int;
+  pub fn item_opts_off(_:ITEM, _:c_int) -> c_int;
+  pub fn item_opts_on(_:ITEM, _:c_int) -> c_int;
+  pub fn menu_driver(_:MENU, _:c_int) -> c_int;
+  pub fn menu_opts_off(_:MENU, _:c_int) -> c_int;
+  pub fn menu_opts_on(_:MENU, _:c_int) -> c_int;
+  pub fn menu_pad(_:MENU) -> c_int;
+  pub fn pos_menu_cursor(_:MENU) -> c_int;
+  pub fn post_menu(_:MENU) -> c_int;
+  pub fn scale_menu(_:MENU, _:*mut c_int, _:*mut c_int) -> c_int;
+  pub fn set_current_item(_:MENU, _:ITEM) -> c_int;
+  pub fn set_item_init(_:MENU, _:HOOK) -> c_int;
+  pub fn set_item_opts(_:ITEM, _:c_int) -> c_int;
+  pub fn set_item_term(_:MENU, _:HOOK) -> c_int;
+  pub fn set_item_value(_:ITEM, _:c_int) -> c_int;
+  pub fn set_menu_back(_:MENU, _:chtype) -> c_int;
+  pub fn set_menu_fore(_:MENU, _:chtype) -> c_int;
+  pub fn set_menu_format(_:MENU, _:c_int, _:c_int) -> c_int;
+  pub fn set_menu_grey(_:MENU, _:chtype) -> c_int;
+  pub fn set_menu_init(_:MENU, _:HOOK) -> c_int;
+  pub fn set_menu_items(_:MENU, _:*mut ITEM) -> c_int;
+  pub fn set_menu_mark(_:MENU, _:*const c_char) -> c_int;
+  pub fn set_menu_opts(_:MENU, _:c_int) -> c_int;
+  pub fn set_menu_pad(_:MENU, _:c_int) -> c_int;
+  pub fn set_menu_pattern(_:MENU, _:*const c_char) -> c_int;
+  pub fn set_menu_sub(_:MENU, _:WINDOW) -> c_int;
+  pub fn set_menu_term(_:MENU, _:HOOK) -> c_int;
+  pub fn set_menu_win(_:MENU, _:WINDOW) -> c_int;
+  pub fn set_top_row(_:MENU, _:c_int) -> c_int;
+  pub fn top_row(_:MENU) -> c_int;
+  pub fn unpost_menu(_:MENU) -> c_int;
+  pub fn menu_request_by_name(_:*const c_char) -> c_int;
+  pub fn set_menu_spacing(_:MENU, _:c_int, _:c_int, _:c_int) -> c_int;
+  pub fn menu_spacing(_:MENU, _:*mut c_int, _:*mut c_int, _:*mut c_int) -> c_int;
+
+  pub fn item_value(_:ITEM) -> c_int;
+  pub fn item_visible(_:ITEM) -> c_int;
+
+  pub fn menu_format(_:MENU, _:*mut c_int, _:*mut c_int);
+}

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -1,0 +1,3 @@
+mod ll;
+pub mod wrapper;
+pub mod constants;

--- a/src/menu/wrapper.rs
+++ b/src/menu/wrapper.rs
@@ -1,0 +1,450 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+use std::str;
+use std::ptr;
+use std::slice;
+use std::ffi::{CStr, CString};
+use libc::*;
+use menu::ll;
+use ll::{WINDOW, chtype};
+use constants::TRUE;
+
+pub type MENU = ll::MENU;
+pub type ITEM = ll::ITEM;
+pub type HOOK = ll::HOOK;
+
+#[cfg(feature="menu")]
+pub fn menu_items(menu: MENU) -> Vec<ITEM> { 
+  unsafe { 
+    slice::from_raw_parts(super::ll::menu_items(menu), item_count(menu) as usize).to_vec()
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn current_item(menu: MENU) -> ITEM {
+  unsafe {
+    super::ll::current_item(menu)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn new_item<T: Into<Vec<u8>>>(name: T, description: T) -> ITEM {
+  unsafe {
+    super::ll::new_item(CString::new(name).unwrap().into_ptr(), CString::new(description).unwrap().into_ptr())
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn new_menu(items: &mut Vec<ITEM>) -> MENU {
+  unsafe { 
+    items.push(ptr::null_mut());
+    let menu = super::ll::new_menu(items.as_mut_ptr());
+    items.pop();
+
+    menu
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn item_opts(item: ITEM) -> i32 {
+  unsafe {
+    super::ll::item_opts(item)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn menu_opts(menu: MENU) -> i32 {
+  unsafe {
+    super::ll::menu_opts(menu)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn menu_sub(menu: MENU) -> WINDOW {
+  unsafe {
+    super::ll::menu_sub(menu)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn item_init(menu: MENU) -> HOOK {
+  unsafe {
+    super::ll::item_init(menu)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn item_term(menu: MENU) -> HOOK {
+  unsafe {
+    super::ll::item_term(menu)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn menu_init(menu: MENU) -> HOOK {
+  unsafe {
+    super::ll::menu_init(menu)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn menu_term(menu: MENU) -> HOOK {
+  unsafe {
+    super::ll::menu_term(menu)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn menu_win(menu: MENU) -> WINDOW {
+  unsafe {
+    super::ll::menu_win(menu)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn item_description(item: ITEM) -> String {
+  unsafe {
+    ptr_to_string(super::ll::item_description(item))
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn item_name(item: ITEM) -> String {
+  unsafe {
+    ptr_to_string(super::ll::item_name(item))
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn menu_mark(menu: MENU) -> String {
+  unsafe {
+    ptr_to_string(super::ll::menu_mark(menu))
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn menu_request_name(request: i32) -> String {
+  unsafe {
+    ptr_to_string(super::ll::menu_request_name(request))
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn menu_pattern(menu: MENU) -> String {
+  unsafe {
+    ptr_to_string(super::ll::menu_pattern(menu))
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn menu_back(menu: MENU) -> chtype {
+  unsafe {
+    super::ll::menu_back(menu)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn menu_fore(menu: MENU) -> chtype {
+  unsafe {
+    super::ll::menu_fore(menu)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn menu_grey(menu: MENU) -> chtype {
+  unsafe {
+    super::ll::menu_grey(menu)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn free_item(item: ITEM) -> i32 {
+  unsafe {
+    CString::from_ptr(item as *const i8);
+    super::ll::free_item(item)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn free_menu(menu: MENU) -> i32 {
+  unsafe {
+    super::ll::free_menu(menu)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn item_count(menu: MENU) -> i32 {
+  unsafe {
+    super::ll::item_count(menu)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn item_index(item: ITEM) -> i32 {
+  unsafe {
+    super::ll::item_index(item)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn item_opts_off(item: ITEM, opts: i32) -> i32 {
+  unsafe {
+    super::ll::item_opts_off(item, opts)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn item_opts_on(item: ITEM, opts: i32) -> i32 {
+  unsafe {
+    super::ll::item_opts_on(item, opts)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn menu_driver(menu: MENU, c: i32) -> i32 {
+  unsafe {
+    super::ll::menu_driver(menu, c)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn menu_opts_off(menu: MENU, opts: i32) -> i32 {
+  unsafe {
+    super::ll::menu_opts_off(menu, opts)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn menuopts_on(menu: MENU, opts: i32) -> i32 {
+  unsafe {
+    super::ll::menu_opts_on(menu, opts)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn menu_pad(menu: MENU) -> i32 {
+  unsafe {
+    super::ll::menu_pad(menu)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn pos_menu_cursor(menu: MENU) -> i32 {
+  unsafe {
+    super::ll::pos_menu_cursor(menu)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn post_menu(menu: MENU) -> i32 {
+  unsafe {
+    super::ll::post_menu(menu)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn scale_menu(menu: MENU, rows: &mut i32, cols: &mut i32) -> i32 {
+  unsafe {
+    super::ll::scale_menu(menu, rows as *mut c_int, cols as *mut c_int)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn set_current_item(menu: MENU, item: ITEM) -> i32 {
+  unsafe {
+    super::ll::set_current_item(menu, item)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn set_item_init(menu: MENU, hook: HOOK) -> i32 {
+  unsafe {
+    super::ll::set_item_init(menu, hook)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn set_item_opts(item: ITEM, opts: i32) -> i32 {
+  unsafe {
+    super::ll::set_item_opts(item, opts)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn set_item_term(menu: MENU, hook: HOOK) -> i32 {
+  unsafe {
+    super::ll::set_item_term(menu, hook)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn set_item_value(item: ITEM, value: bool) -> i32 {
+  unsafe {
+    super::ll::set_item_value(item, value as i32)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn set_menu_back(menu: MENU, attr: chtype) -> i32 {
+  unsafe {
+    super::ll::set_menu_back(menu, attr)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn set_menu_fore(menu: MENU, attr: chtype) -> i32 {
+  unsafe {
+    super::ll::set_menu_fore(menu, attr)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn set_menu_grey(menu: MENU, attr: chtype) -> i32 {
+  unsafe {
+    super::ll::set_menu_grey(menu, attr)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn set_menu_format(menu: MENU, rows: i32, cols: i32) -> i32 {
+  unsafe {
+    super::ll::set_menu_format(menu, rows, cols)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn set_menu_init(menu: MENU, hook: HOOK) -> i32 {
+  unsafe {
+    super::ll::set_menu_init(menu, hook)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn set_menu_items(menu: MENU, items: &mut Vec<ITEM>) -> i32 {
+  unsafe { 
+    items.push(ptr::null_mut());
+    let ret = super::ll::set_menu_items(menu, items.as_mut_ptr());
+    items.pop();
+
+    ret
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn set_menu_mark<T: Into<Vec<u8>>>(menu: MENU, mark: T) -> i32 {
+  unsafe {
+    super::ll::set_menu_mark(menu, CString::new(mark).unwrap().into_ptr())
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn set_menu_opts(menu: MENU, opts: i32) -> i32 {
+  unsafe {
+    super::ll::set_menu_opts(menu, opts)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn set_menu_pad(menu: MENU, opts: i32) -> i32 {
+  unsafe {
+    super::ll::set_menu_pad(menu, opts)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn set_menu_pattern<T: Into<Vec<u8>>>(menu: MENU, pattern: T) -> i32 {
+  unsafe {
+    super::ll::set_menu_pattern(menu, CString::new(pattern).unwrap().into_ptr())
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn set_menu_sub(menu: MENU, win: WINDOW) -> i32 {
+  unsafe {
+    super::ll::set_menu_sub(menu, win)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn set_menu_term(menu: MENU, hook: HOOK) -> i32 {
+  unsafe {
+    super::ll::set_menu_term(menu, hook)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn set_menu_win(menu: MENU, win: WINDOW) -> i32 {
+  unsafe {
+    super::ll::set_menu_win(menu, win)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn set_top_row(menu: MENU, row: i32) -> i32 {
+  unsafe {
+    super::ll::set_top_row(menu, row)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn top_row(menu: MENU) -> i32 {
+  unsafe {
+    super::ll::top_row(menu)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn unpost_menu(menu: MENU) -> i32 {
+  unsafe {
+    super::ll::unpost_menu(menu)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn menu_request_by_name<T: Into<Vec<u8>>>(name: T) -> i32 {
+  unsafe {
+    super::ll::menu_request_by_name(CString::new(name).unwrap().as_ptr())
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn set_menu_spacing(menu: MENU, spc_description: i32, spc_rows: i32, spc_columns: i32) -> i32 {
+  unsafe {
+    super::ll::set_menu_spacing(menu, spc_description, spc_rows, spc_columns)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn menu_spacing(menu: MENU, spc_description: &mut i32, spc_rows: &mut i32, spc_columns: &mut i32) -> i32 {
+  unsafe {
+    super::ll::menu_spacing(menu, spc_description as *mut i32, spc_rows as *mut i32, spc_columns as *mut i32)
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn item_value(item: ITEM) -> bool {
+  unsafe {
+    super::ll::item_value(item) == TRUE
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn item_visible(item: ITEM) -> bool {
+  unsafe {
+    super::ll::item_visible(item) == TRUE
+  }
+}
+
+#[cfg(feature="menu")]
+pub fn menu_format(menu: MENU, rows: &mut i32, cols: &mut i32) {
+  unsafe {
+    super::ll::menu_format(menu, rows as *mut i32, cols as *mut i32);
+  }
+}
+
+pub fn ptr_to_string(ptr: *const c_char) -> String {
+  unsafe {
+    str::from_utf8_unchecked(CStr::from_ptr(ptr).to_bytes()).to_owned()
+  }
+}

--- a/src/ncurses.rs
+++ b/src/ncurses.rs
@@ -13,6 +13,9 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
+#![cfg(feature="menu")]
+#![feature(cstr_memory)]
+
 extern crate libc;
 
 use std::mem;
@@ -21,6 +24,8 @@ use std::ffi::{CString, CStr};
 use self::ll::{FILE_p};
 pub use self::constants::*;
 pub use self::panel::wrapper::*;
+pub use self::menu::wrapper::*;
+pub use self::menu::constants::*;
 
 #[cfg(target_arch = "x86_64")]
 pub type chtype = u64;
@@ -34,6 +39,7 @@ pub type NCURSES_ATTR_T = attr_t;
 pub mod ll;
 pub mod constants;
 pub mod panel;
+pub mod menu;
 
 trait FromCStr {
     fn from_c_str(s: *const libc::c_char) -> Self;


### PR DESCRIPTION
This pull request adds menu support as an optional feature to the crate.

I meant to add this feature for a while but couldn't because it wasn't possible to allocate a C string in Rust and transfer ownership to C without leaking. This [feature](https://github.com/rust-lang/rust/pull/25777) has been finally added to rust recently.

It has only been added to nightly and NOT yet to rust stable.