### PR TITLE
Fix deprecated functions in menu mod

### DIFF
--- a/examples/ex_5.rs
+++ b/examples/ex_5.rs
@@ -1,7 +1,9 @@
+#[allow(unused_imports)]
 extern crate ncurses;
 
 use ncurses::*;
 
+#[cfg(feature="menu")]
 fn main() {
   /* Initialize curses */
   initscr();
@@ -77,4 +79,9 @@ fn main() {
   free_menu(my_menu);
 
   endwin();
+}
+
+#[cfg(not(feature="menu"))]
+fn main()
+{
 }

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -31,18 +31,12 @@ pub type short_p = *mut c_short;
 pub type void_p = *const c_void;
 pub type char_p = *const c_char;
 pub type chtype_p = *const chtype;
-pub type WINDOW = *mut WINDOW_impl;
-pub type SCREEN = *mut SCREEN_impl;
+pub type WINDOW = *mut i8;
+pub type SCREEN = *mut i8;
 pub type FILE_p = *mut FILE;
 pub type va_list = *mut u8;
 
 /* Custom Types. */
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct WINDOW_impl;
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct SCREEN_impl;
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MEVENT { pub id: c_short, pub x: c_int, pub y: c_int, pub z: c_int, pub bstate: mmask_t}

--- a/src/menu/ll.rs
+++ b/src/menu/ll.rs
@@ -4,16 +4,9 @@
 use libc::{c_int, c_char, c_void};
 use ll::{WINDOW, chtype, c_bool};
 
-pub type MENU = *mut MENU_impl;
-pub type ITEM = *mut ITEM_impl;
+pub type MENU = *mut i8;
+pub type ITEM = *mut i8;
 pub type HOOK = Option<extern "C" fn(MENU)>;
-
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct MENU_impl;
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct ITEM_impl;
 
 #[cfg(feature="menu")] #[link(name="menu")]
 extern {
@@ -43,7 +36,6 @@ extern {
   pub fn menu_fore(_:MENU) -> chtype;
   pub fn menu_grey(_:MENU) -> chtype;
 
-  pub fn free_item(_:ITEM) -> c_int;
   pub fn free_menu(_:MENU) -> c_int;
   pub fn item_count(_:MENU) -> c_int;
   pub fn item_index(_:ITEM) -> c_int;

--- a/src/menu/wrapper.rs
+++ b/src/menu/wrapper.rs
@@ -15,8 +15,8 @@ pub type ITEM = ll::ITEM;
 pub type HOOK = ll::HOOK;
 
 #[cfg(feature="menu")]
-pub fn menu_items(menu: MENU) -> Vec<ITEM> { 
-  unsafe { 
+pub fn menu_items(menu: MENU) -> Vec<ITEM> {
+  unsafe {
     slice::from_raw_parts(super::ll::menu_items(menu), item_count(menu) as usize).to_vec()
   }
 }
@@ -31,13 +31,13 @@ pub fn current_item(menu: MENU) -> ITEM {
 #[cfg(feature="menu")]
 pub fn new_item<T: Into<Vec<u8>>>(name: T, description: T) -> ITEM {
   unsafe {
-    super::ll::new_item(CString::new(name).unwrap().into_ptr(), CString::new(description).unwrap().into_ptr())
+    super::ll::new_item(CString::new(name).unwrap().into_raw(), CString::new(description).unwrap().into_raw())
   }
 }
 
 #[cfg(feature="menu")]
 pub fn new_menu(items: &mut Vec<ITEM>) -> MENU {
-  unsafe { 
+  unsafe {
     items.push(ptr::null_mut());
     let menu = super::ll::new_menu(items.as_mut_ptr());
     items.pop();
@@ -159,10 +159,9 @@ pub fn menu_grey(menu: MENU) -> chtype {
 }
 
 #[cfg(feature="menu")]
-pub fn free_item(item: ITEM) -> i32 {
+pub fn free_item(item: ITEM) {
   unsafe {
-    CString::from_ptr(item as *const i8);
-    super::ll::free_item(item)
+    CString::from_raw(item as *mut i8);
   }
 }
 
@@ -322,7 +321,7 @@ pub fn set_menu_init(menu: MENU, hook: HOOK) -> i32 {
 
 #[cfg(feature="menu")]
 pub fn set_menu_items(menu: MENU, items: &mut Vec<ITEM>) -> i32 {
-  unsafe { 
+  unsafe {
     items.push(ptr::null_mut());
     let ret = super::ll::set_menu_items(menu, items.as_mut_ptr());
     items.pop();
@@ -334,7 +333,7 @@ pub fn set_menu_items(menu: MENU, items: &mut Vec<ITEM>) -> i32 {
 #[cfg(feature="menu")]
 pub fn set_menu_mark<T: Into<Vec<u8>>>(menu: MENU, mark: T) -> i32 {
   unsafe {
-    super::ll::set_menu_mark(menu, CString::new(mark).unwrap().into_ptr())
+    super::ll::set_menu_mark(menu, CString::new(mark).unwrap().into_raw())
   }
 }
 
@@ -355,7 +354,7 @@ pub fn set_menu_pad(menu: MENU, opts: i32) -> i32 {
 #[cfg(feature="menu")]
 pub fn set_menu_pattern<T: Into<Vec<u8>>>(menu: MENU, pattern: T) -> i32 {
   unsafe {
-    super::ll::set_menu_pattern(menu, CString::new(pattern).unwrap().into_ptr())
+    super::ll::set_menu_pattern(menu, CString::new(pattern).unwrap().into_raw())
   }
 }
 

--- a/src/ncurses.rs
+++ b/src/ncurses.rs
@@ -13,8 +13,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-#![cfg_attr(feature = "menu", feature(cstr_memory))]
-
 extern crate libc;
 
 use std::mem;

--- a/src/panel/ll.rs
+++ b/src/panel/ll.rs
@@ -4,11 +4,7 @@
 use libc::{ c_int, c_void };
 use ll::WINDOW;
 
-pub type PANEL = *mut PANEL_impl;
-
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct PANEL_impl;
+pub type PANEL = *mut i8;
 
 #[cfg(feature="panel")] #[link(name="panel")]
 extern {

--- a/src/panel/wrapper.rs
+++ b/src/panel/wrapper.rs
@@ -57,4 +57,4 @@ pub fn replace_panel(panel: PANEL, window: WINDOW) -> i32
 
 #[cfg(feature="panel")]
 pub fn panel_hidden(panel: PANEL) -> bool
-{ unsafe { ll::panel_hidden(panel) == TRUE } }
+{ unsafe { ll::panel_hidden(panel) != 0 } }


### PR DESCRIPTION
This PR fixes calls to deprecated functions in the menu mod as well as some other minor stuff.

* The menu mod unfortuanitly still requires rust nightly on which ``into_ptr`` and ``from_ptr`` have been renamed to ``into_raw`` and ``from_raw``
* Changed the menu example to only compile if the menu feature is enabled to avoid errors when executing ``cargo test``
* Fixed the ``warning: found zero-size struct in foreign module, consider adding a member to this struct, #[warn(improper_ctypes)] on by default`` warnings