### PR TITLE
Make type of wattron, wattroff, wattrset consistent with non-window versions

### DIFF
--- a/src/ll.rs
+++ b/src/ll.rs
@@ -266,9 +266,9 @@ macro_rules! define_sharedffi(
             pub fn waddchstr(_:WINDOW,_:chtype_p) -> c_int;
             pub fn waddnstr(_:WINDOW,_:char_p,_:c_int) -> c_int;
             pub fn waddstr(_:WINDOW,_:char_p) -> c_int;
-            pub fn wattron(_:WINDOW, _:c_int) -> c_int;
-            pub fn wattroff(_:WINDOW, _:c_int) -> c_int;
-            pub fn wattrset(_:WINDOW, _:c_int) -> c_int;
+            pub fn wattron(_:WINDOW, _:NCURSES_ATTR_T) -> c_int;
+            pub fn wattroff(_:WINDOW, _:NCURSES_ATTR_T) -> c_int;
+            pub fn wattrset(_:WINDOW, _:NCURSES_ATTR_T) -> c_int;
             pub fn wattr_get(_:WINDOW, _:attr_t_p, _:short_p, _:void_p) -> c_int;
             pub fn wattr_on(_:WINDOW, _:attr_t, _:void_p) -> c_int;
             pub fn wattr_off(_:WINDOW, _:attr_t, _:void_p) -> c_int;

--- a/src/ncurses.rs
+++ b/src/ncurses.rs
@@ -1300,15 +1300,15 @@ pub fn waddstr(w: WINDOW, s: &str) -> i32
 { unsafe { ll::waddstr(w, s.to_c_str().as_ptr()) } }
 
 
-pub fn wattron(w: WINDOW, attr: i32) -> i32
+pub fn wattron(w: WINDOW, attr: NCURSES_ATTR_T) -> i32
 { unsafe { ll::wattron(w, attr) } }
 
 
-pub fn wattroff(w: WINDOW, attr: i32) -> i32
+pub fn wattroff(w: WINDOW, attr: NCURSES_ATTR_T) -> i32
 { unsafe { ll::wattroff(w, attr) } }
 
 
-pub fn wattrset(w: WINDOW, attr: i32) -> i32
+pub fn wattrset(w: WINDOW, attr: NCURSES_ATTR_T) -> i32
 { unsafe { ll::wattrset(w, attr) } }
 
 


### PR DESCRIPTION
In my copy of ncurses.h, `NCURSES_ATTR_T` is #defined as `int`, so the types are the same in the C API. All of the documentation I can find lists the same type for both sets of functions also, so I think that the different signatures in the header file is just a result of auto-generating function prototypes.