### PR TITLE
Expose wget_wch

### DIFF
--- a/examples/ex_7.rs
+++ b/examples/ex_7.rs
@@ -1,0 +1,76 @@
+/*
+    Copyright © 2013 Free Software Foundation, Inc
+    See licensing in LICENSE file
+
+    File: examples/ex_7.rs
+    Author: Jesse 'Jeaye' Wilkerson
+    Description:
+      Basic input and attribute example, using the Unicode-aware get_wch functions.
+*/
+
+extern crate ncurses;
+
+use std::char;
+use ncurses::*;
+
+fn main()
+{
+  let locale_conf = LcCategory::all;
+  setlocale(locale_conf, "en_US.UTF-8");
+
+  /* Setup ncurses. */
+  initscr();
+  raw();
+
+  /* Require input within 2 seconds. */
+  halfdelay(20);
+  /* Enable mouse events. */
+  mousemask(ALL_MOUSE_EVENTS as u64, None);
+
+  /* Allow for extended keyboard (like F1). */
+  keypad(stdscr, true);
+  noecho();
+
+  /* Prompt for a character. */
+  printw("Enter a character within 2 seconds: ");
+
+  /* Wait for input. */
+  let ch = wget_wch(stdscr);
+  match ch {
+    Some(WchResult::KeyCode(KEY_MOUSE)) => {
+      /* Enable attributes and output message. */
+      attron(A_BOLD() | A_BLINK());
+      printw("\nMouse");
+      attroff(A_BOLD() | A_BLINK());
+      printw(" pressed");
+    }
+
+    Some(WchResult::KeyCode(_)) => {
+      /* Enable attributes and output message. */
+      attron(A_BOLD() | A_BLINK());
+      printw("\nKeycode");
+      attroff(A_BOLD() | A_BLINK());
+      printw(" pressed");
+    }
+
+    Some(WchResult::Char(c)) => {
+      /* Enable attributes and output message. */
+      printw("\nKey pressed: ");
+      attron(A_BOLD() | A_BLINK());
+      printw(format!("{}\n", char::from_u32(c as u32).expect("Invalid char")).as_ref());
+      attroff(A_BOLD() | A_BLINK());
+    }
+
+    None => {
+      printw("\nYou didn't enter a character in time!");
+    }
+  }
+
+  /* Refresh, showing the previous message. */
+  refresh();
+
+  /* Wait for one more character before exiting. Disable the input timeout. */
+  nocbreak();
+  getch();
+  endwin();
+}

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -289,6 +289,10 @@ macro_rules! define_sharedffi(
             pub fn werase(_:WINDOW) -> c_int;
             pub fn wgetch(_:WINDOW) -> c_int;
             pub fn wget_wch(_:WINDOW, _:*mut winttype) -> c_int;
+            pub fn mvwget_wch(_:WINDOW, _:c_int, _:c_int, _:*mut winttype) -> c_int;
+            pub fn mvget_wch(_:c_int, _: c_int, _:*mut winttype) -> c_int;
+            pub fn get_wch(_:*mut winttype) -> c_int;
+            pub fn unget_wch(_:winttype) -> c_int;
             pub fn wgetnstr(_:WINDOW,_:char_p,_:c_int) -> c_int;
             pub fn wgetstr(_:WINDOW, _:char_p) -> c_int;
             pub fn whline(_:WINDOW, _:chtype, _:c_int) -> c_int;

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -20,6 +20,7 @@ pub type c_bool = ::libc::c_uchar;
 pub type chtype = c_ulong;
 #[cfg(not(target_arch = "x86_64"))]
 pub type chtype = c_uint;
+pub type winttype = c_uint;
 
 pub type mmask_t = chtype;
 pub type attr_t = chtype;
@@ -287,6 +288,7 @@ macro_rules! define_sharedffi(
             pub fn wechochar(_:WINDOW, _:chtype) -> c_int;
             pub fn werase(_:WINDOW) -> c_int;
             pub fn wgetch(_:WINDOW) -> c_int;
+            pub fn wget_wch(_:WINDOW, _:*mut winttype) -> c_int;
             pub fn wgetnstr(_:WINDOW,_:char_p,_:c_int) -> c_int;
             pub fn wgetstr(_:WINDOW, _:char_p) -> c_int;
             pub fn whline(_:WINDOW, _:chtype, _:c_int) -> c_int;

--- a/src/ncurses.rs
+++ b/src/ncurses.rs
@@ -308,7 +308,7 @@ pub fn getch() -> i32
 { unsafe { ll::getch() } }
 
 pub enum WchResult {
-    KeyCode(chtype),
+    KeyCode(i32),
     Char(winttype),
 }
 
@@ -320,7 +320,7 @@ pub fn get_wch() -> Option<WchResult> {
                 Some(WchResult::Char(x))
             }
             KEY_CODE_YES => {
-                Some(WchResult::KeyCode(x as chtype))
+                Some(WchResult::KeyCode(x as i32))
             }
             _ => {
                 None
@@ -337,7 +337,7 @@ pub fn mvget_wch(y: i32, x: i32) -> Option<WchResult> {
                 Some(WchResult::Char(result))
             }
             KEY_CODE_YES => {
-                Some(WchResult::KeyCode(result as chtype))
+                Some(WchResult::KeyCode(result as i32))
             }
             _ => {
                 None
@@ -354,7 +354,7 @@ pub fn wget_wch(w: WINDOW) -> Option<WchResult> {
                 Some(WchResult::Char(result))
             }
             KEY_CODE_YES => {
-                Some(WchResult::KeyCode(result as chtype))
+                Some(WchResult::KeyCode(result as i32))
             }
             _ => {
                 None
@@ -371,7 +371,7 @@ pub fn mvwget_wch(w: WINDOW, y: i32, x: i32) -> Option<WchResult> {
                 Some(WchResult::Char(result))
             }
             KEY_CODE_YES => {
-                Some(WchResult::KeyCode(result as chtype))
+                Some(WchResult::KeyCode(result as i32))
             }
             _ => {
                 None

--- a/src/ncurses.rs
+++ b/src/ncurses.rs
@@ -28,6 +28,7 @@ pub use self::menu::constants::*;
 pub type chtype = u64;
 #[cfg(not(target_arch = "x86_64"))]
 pub type chtype = u32;
+pub type winttype = u32;
 
 pub type mmask_t = chtype;
 pub type attr_t = chtype;
@@ -306,6 +307,27 @@ pub fn getbkgd(w: WINDOW) -> chtype
 pub fn getch() -> i32
 { unsafe { ll::getch() } }
 
+pub enum WchResult {
+    KeyCode(chtype),
+    Char(winttype),
+}
+
+pub fn wget_wch(w: WINDOW) -> WchResult {
+    unsafe {
+        let mut x = 0;
+        match ll::wget_wch(w, &mut x) {
+            OK => {
+                WchResult::Char(x)
+            }
+            KEY_CODE_YES => {
+                WchResult::KeyCode(x as chtype)
+            }
+            err => {
+                panic!("wget_wch returned {}", err);
+            }
+        }
+    }
+}
 
 pub fn getnstr(s: &mut String, n: i32) -> i32
 {

--- a/src/ncurses.rs
+++ b/src/ncurses.rs
@@ -312,20 +312,77 @@ pub enum WchResult {
     Char(winttype),
 }
 
-pub fn wget_wch(w: WINDOW) -> WchResult {
+pub fn get_wch() -> Option<WchResult> {
     unsafe {
         let mut x = 0;
-        match ll::wget_wch(w, &mut x) {
+        match ll::get_wch(&mut x) {
             OK => {
-                WchResult::Char(x)
+                Some(WchResult::Char(x))
             }
             KEY_CODE_YES => {
-                WchResult::KeyCode(x as chtype)
+                Some(WchResult::KeyCode(x as chtype))
             }
-            err => {
-                panic!("wget_wch returned {}", err);
+            _ => {
+                None
             }
         }
+    }
+}
+
+pub fn mvget_wch(y: i32, x: i32) -> Option<WchResult> {
+    unsafe {
+        let mut result = 0;
+        match ll::mvget_wch(y, x, &mut result) {
+            OK => {
+                Some(WchResult::Char(result))
+            }
+            KEY_CODE_YES => {
+                Some(WchResult::KeyCode(result as chtype))
+            }
+            _ => {
+                None
+            }
+        }
+    }
+}
+
+pub fn wget_wch(w: WINDOW) -> Option<WchResult> {
+    unsafe {
+        let mut result = 0;
+        match ll::wget_wch(w, &mut result) {
+            OK => {
+                Some(WchResult::Char(result))
+            }
+            KEY_CODE_YES => {
+                Some(WchResult::KeyCode(result as chtype))
+            }
+            _ => {
+                None
+            }
+        }
+    }
+}
+
+pub fn mvwget_wch(w: WINDOW, y: i32, x: i32) -> Option<WchResult> {
+    unsafe {
+        let mut result = 0;
+        match ll::mvwget_wch(w, y, x, &mut result) {
+            OK => {
+                Some(WchResult::Char(result))
+            }
+            KEY_CODE_YES => {
+                Some(WchResult::KeyCode(result as chtype))
+            }
+            _ => {
+                None
+            }
+        }
+    }
+}
+
+pub fn unget_wch(ch: u32) -> i32 {
+    unsafe {
+        ll::unget_wch(ch)
     }
 }
 


### PR DESCRIPTION
This is WIP, just wanted your thoughts on the implementation.

This exposes [`wget_wch`](http://linux.die.net/man/3/get_wch), which is like `getch` but gets a wide character. I've wrapped it in a more Rust-friendly API: the original function takes a pointer to the location to store the input and returns a result indicating whether the character is a keycode or a character. The exposed version returns an enum instead. If you like this approach, I can wrap the rest of the functions.

TODO:
- [x] Handle cbreak
- [x] Wrap rest of functions
- [x] Add example

Also, I noticed that the makefile doesn't quite work on my system, but Cargo can build the examples by simply adding them as binary targets. Would you be interested in a PR to convert to that way of building the examples?