### PR TITLE
refer intrinsic types in ncurses.rs to ll.rs

### DIFF
--- a/src/ncurses.rs
+++ b/src/ncurses.rs
@@ -24,15 +24,12 @@ pub use self::panel::wrapper::*;
 pub use self::menu::wrapper::*;
 pub use self::menu::constants::*;
 
-#[cfg(target_arch = "x86_64")]
-pub type chtype = u64;
-#[cfg(not(target_arch = "x86_64"))]
-pub type chtype = u32;
-pub type winttype = u32;
+pub type chtype = self::ll::chtype;
+pub type winttype = self::ll::winttype;
 
-pub type mmask_t = chtype;
-pub type attr_t = chtype;
-pub type NCURSES_ATTR_T = attr_t;
+pub type mmask_t = self::ll::mmask_t;
+pub type attr_t = self::ll::attr_t;
+pub type NCURSES_ATTR_T = self::ll::NCURSES_ATTR_T;
 
 pub mod ll;
 pub mod constants;


### PR DESCRIPTION
I guess this PR is a code clean up and possibly a bug-fix for issue #78.

ncurses.rs contains its own definitions of chtype, winttype, mmask_t, attr_t, NCURSES_ATTR_T, but I think referring those variable to the ones in ll.rs is more appropriate.

rustc can now compile the library on Windows and I tested compilation of the library (and only the library) on Linux. However, I am still struggling about linking libncursesw (maybe it's msys-ncursesw6 on Windows?), and the Linux environment isn't owned by me and it doesn't have libncurses(w).so installed, so the changes are untested.