### PR TITLE
Wrap extern static constants in safe functions

### DIFF
--- a/examples/ex_2.rs
+++ b/examples/ex_2.rs
@@ -20,7 +20,7 @@ fn main()
   raw();
 
   /* Allow for extended keyboard (like F1). */
-  keypad(stdscr, true);
+  keypad(stdscr(), true);
   noecho();
 
   /* Prompt for a character. */

--- a/examples/ex_3.rs
+++ b/examples/ex_3.rs
@@ -47,13 +47,13 @@ fn main()
 
   /* Start ncurses. */
   initscr();
-  keypad(stdscr, true);
+  keypad(stdscr(), true);
   noecho();
 
   /* Get the screen bounds. */
   let mut max_x = 0;
   let mut max_y = 0;
-  getmaxyx(stdscr, &mut max_y, &mut max_x);
+  getmaxyx(stdscr(), &mut max_y, &mut max_x);
 
   /* Read the whole file. */
   for ch in reader
@@ -65,7 +65,7 @@ fn main()
     /* Get the current position on the screen. */
     let mut cur_x = 0;
     let mut cur_y = 0;
-    getyx(stdscr, &mut cur_y, &mut cur_x);
+    getyx(stdscr(), &mut cur_y, &mut cur_x);
 
     if cur_y == (max_y - 1)
     {

--- a/examples/ex_4.rs
+++ b/examples/ex_4.rs
@@ -24,7 +24,7 @@ fn main()
   raw();
 
   /* Allow for extended keyboard (like F1). */
-  keypad(stdscr, true);
+  keypad(stdscr(), true);
   noecho();
 
   /* Invisible cursor. */
@@ -32,13 +32,13 @@ fn main()
 
   /* Status/help info. */
   printw("Use the arrow keys to move");
-  mvprintw(LINES - 1, 0, "Press F1 to exit");
+  mvprintw(LINES() - 1, 0, "Press F1 to exit");
   refresh();
 
   /* Get the screen bounds. */
   let mut max_x = 0;
   let mut max_y = 0;
-  getmaxyx(stdscr, &mut max_y, &mut max_x);
+  getmaxyx(stdscr(), &mut max_y, &mut max_x);
 
   /* Start in the center. */
   let mut start_y = (max_y - WINDOW_HEIGHT) / 2;

--- a/examples/ex_6.rs
+++ b/examples/ex_6.rs
@@ -102,7 +102,7 @@ impl Pager
   {
     /* Start ncurses. */
     initscr();
-    keypad(stdscr, true);
+    keypad(stdscr(), true);
     noecho();
 
     /* Start colors. */
@@ -130,7 +130,7 @@ impl Pager
     bkgd(' ' as chtype | COLOR_PAIR(COLOR_PAIR_DEFAULT) as chtype);
 
     /* Get the screen bounds. */
-    getmaxyx(stdscr, &mut self.screen_height, &mut self.screen_width);
+    getmaxyx(stdscr(), &mut self.screen_height, &mut self.screen_width);
   }
 
   /* Returns the word and delimiter following it. */
@@ -304,7 +304,7 @@ fn main()
     let leftover_attr = pager.highlight_word(format!("{}", leftover).as_ref());
 
     /* Get the current position on the screen. */
-    getyx(stdscr, &mut pager.curr_y, &mut pager.curr_x);
+    getyx(stdscr(), &mut pager.curr_y, &mut pager.curr_x);
 
     if pager.curr_y == (pager.screen_height - 1)
     {

--- a/examples/ex_7.rs
+++ b/examples/ex_7.rs
@@ -28,14 +28,14 @@ fn main()
   mousemask(ALL_MOUSE_EVENTS as u64, None);
 
   /* Allow for extended keyboard (like F1). */
-  keypad(stdscr, true);
+  keypad(stdscr(), true);
   noecho();
 
   /* Prompt for a character. */
   printw("Enter a character within 2 seconds: ");
 
   /* Wait for input. */
-  let ch = wget_wch(stdscr);
+  let ch = wget_wch(stdscr());
   match ch {
     Some(WchResult::KeyCode(KEY_MOUSE)) => {
       /* Enable attributes and output message. */

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -13,22 +13,49 @@
 use libc::{ c_char, c_int };
 use super::ll::*;
 
-extern
-{
-  pub static curscr: WINDOW;
-  pub static newscr: WINDOW;
-  pub static stdscr: WINDOW;
-  pub static ttytype: *mut c_char;
-  pub static COLORS: c_int;
-  pub static COLOR_PAIRS: c_int;
-  pub static COLS: c_int;
-  pub static ESCDELAY: c_int;
-  pub static LINES: c_int;
-  pub static TABSIZE: c_int;
+mod wrapped {
+    use libc::{ c_char, c_int };
+    use ll::chtype;
+    use ll::WINDOW;
 
-  /* Line graphics */
-  pub static acs_map: [chtype; 0];
+    extern
+    {
+        pub static curscr: WINDOW;
+        pub static newscr: WINDOW;
+        pub static stdscr: WINDOW;
+        pub static ttytype: *mut c_char;
+        pub static COLORS: c_int;
+        pub static COLOR_PAIRS: c_int;
+        pub static COLS: c_int;
+        pub static ESCDELAY: c_int;
+        pub static LINES: c_int;
+        pub static TABSIZE: c_int;
+
+        /* Line graphics */
+        pub static acs_map: [chtype; 0];
+    }
 }
+
+macro_rules! wrap_extern {
+    ($name:ident: $t:ty) => {
+        pub fn $name() -> $t {
+            unsafe { wrapped::$name }
+        }
+    }
+}
+
+wrap_extern!(curscr: WINDOW);
+wrap_extern!(newscr: WINDOW);
+wrap_extern!(stdscr: WINDOW);
+wrap_extern!(ttytype: *mut c_char);
+wrap_extern!(COLORS: c_int);
+wrap_extern!(COLOR_PAIRS: c_int);
+wrap_extern!(COLS: c_int);
+wrap_extern!(ESCDELAY: c_int);
+wrap_extern!(LINES: c_int);
+wrap_extern!(TABSIZE: c_int);
+wrap_extern!(acs_map: [chtype; 0]);
+
 
 /* Success/Failure. */
 pub const ERR: i32 = -1;

--- a/src/ncurses.rs
+++ b/src/ncurses.rs
@@ -1782,15 +1782,15 @@ pub fn getsyx(y: &mut i32, x: &mut i32)
 {
   unsafe
   {
-    if newscr != ptr::null_mut()
+    if newscr() != ptr::null_mut()
     {
-      if ll::is_leaveok(newscr) == TRUE
+      if ll::is_leaveok(newscr()) == TRUE
       {
         *x = -1 as i32;
         *y = -1 as i32;
       }
       else
-      { getyx(newscr, (y), (x)); }
+      { getyx(newscr(), (y), (x)); }
     }
   }
 }
@@ -1800,16 +1800,16 @@ pub fn setsyx(y: &mut i32, x: &mut i32)
 {
   unsafe
   {
-    if newscr !=(0 as WINDOW)
+    if newscr() !=(0 as WINDOW)
     {
       if *y == -1 && *x == -1
       {
-        ll::leaveok(newscr, 1);
+        ll::leaveok(newscr(), 1);
       }
       else
       {
-        ll::leaveok(newscr, 0);
-        ll::wmove(newscr, *y, *x);
+        ll::leaveok(newscr(), 0);
+        ll::wmove(newscr(), *y, *x);
       }
     }
   }
@@ -1817,7 +1817,7 @@ pub fn setsyx(y: &mut i32, x: &mut i32)
 
 /* Line graphics */
 pub fn NCURSES_ACS(c: char) -> chtype {
-    unsafe { *acs_map.as_ptr().offset(c as isize) }
+    unsafe { *acs_map().as_ptr().offset(c as isize) }
 }
 
 /* VT100 symbols begin here */


### PR DESCRIPTION
Accessing extern static variables is unsafe with the latest rust nightlies.
This PR wraps these variables in an internal module, and exposes safe getter functions instead.