### PR TITLE
Fix stdscr in example accidentally being called

### DIFF
--- a/examples/ex_2.rs
+++ b/examples/ex_2.rs
@@ -20,7 +20,7 @@ fn main()
   raw();
 
   /* Allow for extended keyboard (like F1). */
-  keypad(stdscr(), true);
+  keypad(stdscr, true);
   noecho();
 
   /* Prompt for a character. */


### PR DESCRIPTION
Fixes:

```
error: expected function, found `*mut i8`
  --> examples/ex_2.rs:23:10
   |
23 |   keypad(stdscr(), true);
   |          ^^^^^^^^

error: aborting due to previous error
```