### PR TITLE
Fix ACS characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ Current examples:
 **5.** [Menu Library](https://github.com/jeaye/ncurses-rs/blob/master/examples/ex_5.rs) (requires rust nightly)  
 **6.** [Pager & Syntax Highlighting](https://github.com/jeaye/ncurses-rs/blob/master/examples/ex_6.rs)  
 **7.** [Basic Input & Attributes (Unicode)](https://github.com/jeaye/ncurses-rs/blob/master/examples/ex_7.rs)  
+**8.** [Special ACS Characters](https://github.com/jeaye/ncurses-rs/blob/master/examples/ex_8.rs)  

--- a/examples/ex_8.rs
+++ b/examples/ex_8.rs
@@ -1,0 +1,60 @@
+// Derived from the ncurses Programming Howto, used under the
+// following license:
+
+// Copyright © 2001 by Pradeep Padala.
+
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use, copy,
+// modify, merge, publish, distribute, distribute with modifications,
+// sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+
+extern crate ncurses;
+
+use ncurses::*;
+
+fn main() {
+    initscr();
+
+    printw("Upper left corner           "); addch(ACS_ULCORNER()); printw("\n");
+    printw("Lower left corner           "); addch(ACS_LLCORNER()); printw("\n");
+    printw("Lower right corner          "); addch(ACS_LRCORNER()); printw("\n");
+    printw("Tee pointing right          "); addch(ACS_LTEE()); printw("\n");
+    printw("Tee pointing left           "); addch(ACS_RTEE()); printw("\n");
+    printw("Tee pointing up             "); addch(ACS_BTEE()); printw("\n");
+    printw("Tee pointing down           "); addch(ACS_TTEE()); printw("\n");
+    printw("Horizontal line             "); addch(ACS_HLINE()); printw("\n");
+    printw("Vertical line               "); addch(ACS_VLINE()); printw("\n");
+    printw("Large Plus or cross over    "); addch(ACS_PLUS()); printw("\n");
+    printw("Scan Line 1                 "); addch(ACS_S1()); printw("\n");
+    printw("Scan Line 3                 "); addch(ACS_S3()); printw("\n");
+    printw("Scan Line 7                 "); addch(ACS_S7()); printw("\n");
+    printw("Scan Line 9                 "); addch(ACS_S9()); printw("\n");
+    printw("Diamond                     "); addch(ACS_DIAMOND()); printw("\n");
+    printw("Checker board (stipple)     "); addch(ACS_CKBOARD()); printw("\n");
+    printw("Degree Symbol               "); addch(ACS_DEGREE()); printw("\n");
+    printw("Plus/Minus Symbol           "); addch(ACS_PLMINUS()); printw("\n");
+    printw("Bullet                      "); addch(ACS_BULLET()); printw("\n");
+    printw("Arrow Pointing Left         "); addch(ACS_LARROW()); printw("\n");
+    printw("Arrow Pointing Right        "); addch(ACS_RARROW()); printw("\n");
+    printw("Arrow Pointing Down         "); addch(ACS_DARROW()); printw("\n");
+    printw("Arrow Pointing Up           "); addch(ACS_UARROW()); printw("\n");
+    printw("Board of squares            "); addch(ACS_BOARD()); printw("\n");
+    printw("Lantern Symbol              "); addch(ACS_LANTERN()); printw("\n");
+    printw("Solid Square Block          "); addch(ACS_BLOCK()); printw("\n");
+    printw("Less/Equal sign             "); addch(ACS_LEQUAL()); printw("\n");
+    printw("Greater/Equal sign          "); addch(ACS_GEQUAL()); printw("\n");
+    printw("Pi                          "); addch(ACS_PI()); printw("\n");
+    printw("Not equal                   "); addch(ACS_NEQUAL()); printw("\n");
+    printw("UK pound sign               "); addch(ACS_STERLING()); printw("\n");
+
+    refresh();
+    getch();
+    endwin();
+}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -18,7 +18,7 @@ mod wrapped {
     use ll::chtype;
     use ll::WINDOW;
 
-    extern
+    extern "C"
     {
         pub static curscr: WINDOW;
         pub static newscr: WINDOW;
@@ -32,7 +32,7 @@ mod wrapped {
         pub static TABSIZE: c_int;
 
         /* Line graphics */
-        pub static acs_map: [chtype; 0];
+        pub static mut acs_map: [chtype; 0];
     }
 }
 
@@ -54,7 +54,11 @@ wrap_extern!(COLS: c_int);
 wrap_extern!(ESCDELAY: c_int);
 wrap_extern!(LINES: c_int);
 wrap_extern!(TABSIZE: c_int);
-wrap_extern!(acs_map: [chtype; 0]);
+pub fn acs_map() -> *const chtype {
+    unsafe {
+        &wrapped::acs_map as *const chtype
+    }
+}
 
 
 /* Success/Failure. */
@@ -283,4 +287,3 @@ pub enum LcCategory {
     time = LC_TIME,
     messages = LC_MESSAGES,
 }
-

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -17,7 +17,7 @@ pub type c_bool = ::libc::c_uchar;
 
 /* Intrinsic types. */
 #[cfg(target_arch = "x86_64")]
-pub type chtype = c_ulong;
+pub type chtype = c_uint;
 #[cfg(not(target_arch = "x86_64"))]
 pub type chtype = c_uint;
 pub type winttype = c_uint;

--- a/src/ncurses.rs
+++ b/src/ncurses.rs
@@ -25,7 +25,7 @@ pub use self::menu::wrapper::*;
 pub use self::menu::constants::*;
 
 #[cfg(target_arch = "x86_64")]
-pub type chtype = u64;
+pub type chtype = u32;
 #[cfg(not(target_arch = "x86_64"))]
 pub type chtype = u32;
 pub type winttype = u32;

--- a/src/ncurses.rs
+++ b/src/ncurses.rs
@@ -1817,7 +1817,7 @@ pub fn setsyx(y: &mut i32, x: &mut i32)
 
 /* Line graphics */
 pub fn NCURSES_ACS(c: char) -> chtype {
-    unsafe { *acs_map().as_ptr().offset(c as isize) }
+    unsafe { *acs_map().offset((c as libc::c_uchar) as isize) as chtype }
 }
 
 /* VT100 symbols begin here */


### PR DESCRIPTION
Fixes #80 

Changes:
- `chtype` should be `u32` on 64-bit platforms
- Use a reference to the `acs_map` array instead of directly indexing it (the latter seems to cause Rust to index into random memory, because when directly using the array, it'll first try to copy it, then return the copy - but since the array is 0-size, it just does nothing and expects that you won't index it)