### PR TITLE
Add a build script to deal with `chtype`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/jeaye/ncurses-rs"
 readme = "README.md"
 keywords = ["ncurses","TUI"]
 license = "MIT"
+build = "build.rs"
+
+[build-dependencies]
+gcc = "0.3"
 
 [dependencies]
 libc = "0.2"
@@ -18,6 +22,9 @@ default=[]
 wide = []
 panel = []
 menu = []
+# Uses a 64-bit type for `chtype` (otherwise a 32-bit type is used).
+# This should be set automagically (when needed) by build.rs
+wide_chtype = []
 
 [lib]
 name = "ncurses"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,49 @@
+extern crate gcc;
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+fn main() {
+    check_chtype_size();
+}
+
+fn check_chtype_size() {
+    let out_dir = env::var("OUT_DIR").expect("cannot get OUT_DIR");
+    let src = format!("{}", Path::new(&out_dir).join("chtype_size.c").display());
+    let bin = format!("{}", Path::new(&out_dir).join("chtype_size").display());
+
+    let mut fp = File::create(&src).expect(&format!("cannot create {}", src));
+    fp.write_all(b"
+#include <assert.h>
+#include <limits.h>
+#include <stdio.h>
+
+#include <ncurses.h>
+
+int main(void)
+{
+    if (sizeof(chtype)*CHAR_BIT == 64) {
+        puts(\"cargo:rustc-cfg=feature=\\\"wide_chtype\\\"\");
+    } else {
+        /* We only support 32-bit and 64-bit chtype. */
+        assert(sizeof(chtype)*CHAR_BIT == 32 && \"unsupported size for chtype\");
+    }
+    return 0;
+}
+    ").expect(&format!("cannot write into {}", src));
+
+    let cfg = gcc::Config::new();
+    let compiler = cfg.get_compiler();
+
+    Command::new(compiler.path()).arg(&src).arg("-o").arg(&bin)
+                                 .status().expect("compilation failed");
+    let features = Command::new(&bin).output()
+                   .expect(&format!("{} failed", bin));
+    print!("{}", String::from_utf8_lossy(&features.stdout));
+
+    std::fs::remove_file(&src).expect(&format!("cannot delete {}", src));
+    std::fs::remove_file(&bin).expect(&format!("cannot delete {}", bin));
+}

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -16,10 +16,10 @@ use libc::{ c_char, c_int, c_short, c_uint, c_ulong, c_void, FILE };
 pub type c_bool = ::libc::c_uchar;
 
 /* Intrinsic types. */
-#[cfg(target_arch = "x86_64")]
-pub type chtype = c_uint;
-#[cfg(not(target_arch = "x86_64"))]
-pub type chtype = c_uint;
+#[cfg(feature="wide_chtype")]
+pub type chtype = u64;
+#[cfg(not(feature="wide_chtype"))]
+pub type chtype = u32;
 pub type winttype = c_uint;
 
 pub type mmask_t = chtype;

--- a/src/ncurses.rs
+++ b/src/ncurses.rs
@@ -24,10 +24,7 @@ pub use self::panel::wrapper::*;
 pub use self::menu::wrapper::*;
 pub use self::menu::constants::*;
 
-#[cfg(target_arch = "x86_64")]
-pub type chtype = u32;
-#[cfg(not(target_arch = "x86_64"))]
-pub type chtype = u32;
+pub type chtype = self::ll::chtype;
 pub type winttype = u32;
 
 pub type mmask_t = chtype;


### PR DESCRIPTION
Hi,

Here is a commit to solve the problems due to the size of `chtype`.

It's not the first time there are problems with the size of `chtype`. I found that it was reported (and solved) in #44, but a recent commit (6064435c284c20d31fd6aaf82b13d093fc0eae91) reintroduced the bug. This causes segmentation fault on some systems: I got hit by this bug when using Cursive on a Debian Jessie. Recent issues, #119 and #120, seems related as well.

The problem is not that easy to solve because the size of `chtype` depends on several parameters (see the commit message of this patch for the gory details), and the only reliable way to define it seems to use a build script.

Note that this is the first time I try to use build.rs (and I'm a beginner with Rust), I don't know if there are good practice to follow for build script (my code may be ugly :/). I'm open to suggestions to clean/improve it before it get merged.

I tested on my Archlinux (OS 64-bit, ncurses v6.0.20161112 => `chtype` is 32-bit) and on a Debian Jessie (OS 64-bit, ncurses v5.9.20140913 => `chtype` is 64-bit) and it seems to be working.