### PR TITLE
Don't link to ncursesw on macos

### DIFF
--- a/src/ll.rs
+++ b/src/ll.rs
@@ -378,5 +378,6 @@ macro_rules! define_sharedffi(
 
 //end macro rules
 
-define_sharedffi!(cfg(feature="wide"), link(name="ncursesw"));
-define_sharedffi!(cfg(not(feature="wide")), link(name="ncurses"));
+// Don't link ncursesw on macos
+define_sharedffi!(cfg(all(feature="wide", not(target_os="macos"))), link(name="ncursesw"));
+define_sharedffi!(cfg(any(not(feature="wide"), target_os="macos")), link(name="ncurses"));


### PR DESCRIPTION
On macOS, the "wide" features are directly part of the `ncurses` library, and there is no `ncursesw`.
Linking to `ncursesw` is therefore a compilation error on macOS.