### PR TITLE
Use pkg-config to provide correct link flags (-l, -L)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ build = "build.rs"
 
 [build-dependencies]
 gcc = "0.3"
+pkg-config = "0.3"
 
 [dependencies]
 libc = "0.2"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 extern crate gcc;
+extern crate pkg_config;
 
 use std::env;
 use std::fs::File;
@@ -43,6 +44,13 @@ int main(void)
     let features = Command::new(&bin).output()
                    .expect(&format!("{} failed", bin));
     print!("{}", String::from_utf8_lossy(&features.stdout));
+
+    let ncurses_names = ["ncurses5", "ncurses"];
+    for ncurses_name in &ncurses_names {
+        if pkg_config::probe_library(ncurses_name).is_ok() {
+            break;
+        }
+    }
 
     std::fs::remove_file(&src).expect(&format!("cannot delete {}", src));
     std::fs::remove_file(&bin).expect(&format!("cannot delete {}", bin));


### PR DESCRIPTION
This depends on the OS, but use pkg-config to discover what flags rust needs to pass when linking the resulting program.

Under opensuse for example, it was trying to link without extra parameters against -lncurses, but that was matching ncurses version 6, which was missing for example the ::LINES() symbol, producing linking errors.

It first tries to go from the most specific pkg-config sometimes called `ncurses5`. If that fails, it should fallback to `ncurses`.