### PR TITLE
Version BUMP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ncurses"
-version = "5.85.0"
+version = "5.86.0"
 authors = [ "contact@jeaye.com" ]
 description = "A very thin wrapper around the ncurses TUI library"
 documentation = "https://github.com/jeaye/ncurses-rs"


### PR DESCRIPTION
I have linux distribution where ncurses
split into ncurses and tinfo. pkg-config
return right link flags, so it would be good to have
ncurses-rs on crates.io with this fix.