### PR TITLE
small bug in example code: pager eating characters

### DIFF
--- a/examples/ex_3.rs
+++ b/examples/ex_3.rs
@@ -76,8 +76,8 @@ fn main()
       clear();
       mv(0, 0);
     }
-    else
-    { addch(ch as chtype); }
+    
+    addch(ch as chtype);
   }
 
   /* Terminate ncurses. */


### PR DESCRIPTION
The example code (I think the 3rd example) had a small bug. When you page forward, the pager was eating chars which should instead be printed.

The fix consisted of making an 'else' branch execute on every iteration.