### PR TITLE
Fix getnstr family functions

### DIFF
--- a/src/ll.rs
+++ b/src/ll.rs
@@ -293,7 +293,7 @@ macro_rules! define_sharedffi(
             pub fn mvget_wch(_:c_int, _: c_int, _:*mut winttype) -> c_int;
             pub fn get_wch(_:*mut winttype) -> c_int;
             pub fn unget_wch(_:winttype) -> c_int;
-            pub fn wgetnstr(_:WINDOW,_:char_p,_:c_int) -> c_int;
+            pub fn wgetnstr(_:WINDOW,_:*const u8,_:c_int) -> c_int;
             pub fn wgetstr(_:WINDOW, _:char_p) -> c_int;
             pub fn whline(_:WINDOW, _:chtype, _:c_int) -> c_int;
             pub fn winch(_:WINDOW) -> chtype;


### PR DESCRIPTION
Fixed `wgetnstr` and implemented rest of `*getnstr`-family through call to `wgetnstr`. Unfortunately I had to change type of string argument in `ll::wgetnstr` from `char_p` to `*const u8`. 