### PR TITLE
menu: fix free_item

### DIFF
--- a/src/menu/ll.rs
+++ b/src/menu/ll.rs
@@ -14,6 +14,7 @@ macro_rules! define_sharedffi(
             pub fn menu_items(_:MENU) -> *mut ITEM;
             pub fn current_item(_:MENU) -> ITEM;
             pub fn new_item(_:*const c_char, _:*const c_char) -> ITEM;
+            pub fn free_item(_:ITEM);
             pub fn new_menu(_:*mut ITEM) -> MENU;
             pub fn item_opts(_:ITEM) -> c_int;
             pub fn menu_opts(_:MENU) -> c_int;

--- a/src/menu/wrapper.rs
+++ b/src/menu/wrapper.rs
@@ -160,8 +160,16 @@ pub fn menu_grey(menu: MENU) -> chtype {
 
 #[cfg(feature="menu")]
 pub fn free_item(item: ITEM) {
-  unsafe {
-    CString::from_raw(item as *mut i8);
+    unsafe {
+        let name = super::ll::item_name(item) as *mut i8;
+        if name.is_null() == false {
+            let _ = CString::from_raw(name);
+        }
+        let desc = super::ll::item_description(item) as *mut i8;
+        if desc.is_null() == false {
+            let _ = CString::from_raw(desc);
+        }
+        super::ll::free_item(item);
   }
 }
 


### PR DESCRIPTION
free the item's name and description.
then free the item itself.

I'm surprised nobody complains as it caused segfault