### PR TITLE
Add resize_term functions

### DIFF
--- a/src/ll.rs
+++ b/src/ll.rs
@@ -123,6 +123,7 @@ macro_rules! define_sharedffi(
             pub fn intrflush(_:WINDOW,_:c_bool) -> c_int;
             pub fn isendwin() -> c_bool;
             pub fn is_linetouched(_:WINDOW,_:c_int) -> c_bool;
+            pub fn is_term_resized(_:c_int, _:c_int) -> c_bool;
             pub fn is_wintouched(_:WINDOW) -> c_bool;
             pub fn keyname(_:c_int) -> *const c_char;
             pub fn keypad(_:WINDOW, _:c_bool) -> c_int;
@@ -206,6 +207,8 @@ macro_rules! define_sharedffi(
             pub fn raw() -> c_int;
             pub fn redrawwin(_:WINDOW) -> c_int;
             pub fn refresh() -> c_int;
+            pub fn resizeterm(_:c_int, _:c_int) -> c_int;
+            pub fn resize_term(_:c_int, _:c_int) -> c_int;
             pub fn resetty() -> c_int;
             pub fn reset_prog_mode() -> c_int;
             pub fn reset_shell_mode() -> c_int;

--- a/src/ncurses.rs
+++ b/src/ncurses.rs
@@ -627,6 +627,10 @@ pub fn is_wintouched(w: WINDOW) -> bool
 { unsafe { ll::is_wintouched(w) == TRUE } }
 
 
+pub fn is_term_resized(lines: i32, cols: i32) -> bool
+{ unsafe { ll::is_term_resized(lines, cols) == TRUE } }
+
+
 pub fn is_cleared(w: WINDOW) -> bool
 { unsafe { ll::is_cleared(w) == TRUE } }
 
@@ -1135,6 +1139,14 @@ pub fn reset_prog_mode() -> i32
 
 pub fn reset_shell_mode() -> i32
 { unsafe { ll::reset_shell_mode() } }
+
+
+pub fn resizeterm(lines: i32, cols: i32) -> i32
+{ unsafe { ll::resizeterm(lines, cols) } }
+
+
+pub fn resize_term(lines: i32, cols: i32) -> i32
+{ unsafe { ll::resize_term(lines, cols) } }
 
 
 pub fn savetty() -> i32


### PR DESCRIPTION
Add the three resize_term functions (resize_term, resizeterm, is_term_resized). I don't see any reason for these to not be a part of the library.

For reference, see http://invisible-island.net/ncurses/man/resizeterm.3x.html or the ncurses man page (specifically the resizeterm man page).