### PR TITLE
Fix closing parenthesis in example 1

### DIFF
--- a/examples/ex_1.rs
+++ b/examples/ex_1.rs
@@ -25,7 +25,7 @@ fn main()
   printw("Hello, world!");
 
   /* Print some unicode(Chinese) string. */
-  // printw("Great Firewall dislike VPN protocol.\nGFW 不喜欢 VPN 协议。";
+  // printw("Great Firewall dislike VPN protocol.\nGFW 不喜欢 VPN 协议。");
 
   /* Update the screen. */
   refresh();


### PR DESCRIPTION
This PR adds a parethesis in [examples/ex_1.rs](https://github.com/jeaye/ncurses-rs/compare/master...dsprenkels:patch-1#diff-27738e418fe65c03484caafb0985e073). Without it, compilation failed, resulting in syntax error.