### PR TITLE
add extended color functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ menu = []
 # Uses a 64-bit type for `chtype` (otherwise a 32-bit type is used).
 # This should be set automagically (when needed) by build.rs
 wide_chtype = []
+extended_colors = ["wide"]
 
 [lib]
 name = "ncurses"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1997,3 +1997,23 @@ pub fn wmouse_trafo(w: *mut WINDOW, y: &mut[i32], x: &mut[i32], to_screen: bool)
 
 pub fn mouse_trafo(y: &mut[i32], x: &mut[i32], to_screen: bool) -> bool
 { unsafe { ll::mouse_trafo(y.as_mut_ptr(), x.as_mut_ptr(), to_screen as ll::c_bool) == TRUE } }
+
+#[cfg(feature = "extended_colors")]
+pub fn init_extended_color(color: i32, r: i32, g: i32, b: i32) -> i32 {
+    unsafe { ll::init_extended_color(color, r, g, b) }
+}
+
+#[cfg(feature = "extended_colors")]
+pub fn init_extended_pair(color: i32, f: i32, b: i32) -> i32 {
+    unsafe { ll::init_extended_pair(color, f, b) }
+}
+
+#[cfg(feature = "extended_colors")]
+pub fn extended_color_content(color: i32, r: &mut i32, g: &mut i32, b: &mut i32) -> i32 {
+    unsafe { ll::extended_color_content(color, r, g, b) }
+}
+
+#[cfg(feature = "extended_colors")]
+pub fn extended_pair_content(pair: i32, f: &mut i32, b: &mut i32) -> i32 {
+    unsafe { ll::extended_pair_content(pair, f, b) }
+}

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -29,6 +29,7 @@ pub type NCURSES_ATTR_T = attr_t;
 /* Pointer types. */
 pub type attr_t_p = *mut attr_t;
 pub type short_p = *mut c_short;
+pub type int_p = *mut c_int;
 pub type void_p = *const c_void;
 pub type char_p = *const c_char;
 pub type chtype_p = *const chtype;
@@ -376,4 +377,13 @@ extern {
     pub fn mouseinterval(_:c_int) -> c_int;
     pub fn wmouse_trafo(_:*mut WINDOW,_:*mut c_int,_:*mut c_int,_:c_bool) -> c_bool;
     pub fn mouse_trafo(_:*mut c_int,_:*mut c_int,_:c_bool) -> c_bool;
+}
+
+/// Extended color support. Requires ncurses6.
+#[cfg(feature = "extended_colors")]
+extern {
+    pub fn init_extended_color(_: c_int, _: c_int, _: c_int, _: c_int) -> c_int;
+    pub fn init_extended_pair(_: c_int, _: c_int, _: c_int) -> c_int;
+    pub fn extended_color_content(_: c_int, _: int_p, _: int_p, _: int_p) -> c_int;
+    pub fn extended_pair_content(_: c_int, _: int_p, _: int_p) -> c_int;
 }


### PR DESCRIPTION
Fixes #154 

I put this behind a feature, because I'm not sure that there's a smarter way to detect ncurses 6.

I used the following test program to test this:

```rust
extern crate ncurses;

use std::process;

use ncurses::*;

fn failed() {
    endwin();
    println!("failed");
    process::exit(1);
}

fn main() {
    initscr();
    start_color();

    let r = init_extended_color(COLOR_RED.into(), 255 * 1000 / 256, 100 * 1000 / 256, 0);
    if r != OK {
        failed();
    }

    let r = init_extended_pair(2, COLOR_RED.into(), COLOR_BLACK.into());
    if r != OK {
        failed();
    }
    attron(COLOR_PAIR(2));
    printw("TRUECOLOR");
    refresh();

    getch();
    endwin();
}
```