### PR TITLE
Add missing Debug implementations

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -277,6 +277,7 @@ pub const LC_NUMERIC: c_int = 4;
 pub const LC_TIME: c_int = 5;
 pub const LC_MESSAGES: c_int = 6;
 
+#[derive(Debug)]
 #[repr(i32)]
 pub enum LcCategory {
     all = LC_ALL,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,6 @@
       Safe wrappers for ncurses functions.
 */
 
-#![crate_name = "ncurses"]
-#![crate_type = "lib"]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1789,7 +1789,7 @@ pub fn getsyx(y: &mut i32, x: &mut i32)
         *y = -1 as i32;
       }
       else
-      { getyx(newscr(), (y), (x)); }
+      { getyx(newscr(), y, x); }
     }
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![warn(missing_debug_implementations)]
 
 extern crate libc;
 
@@ -65,7 +66,7 @@ impl <'a>ToCStr for &'a str {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum CURSOR_VISIBILITY
 {
   CURSOR_INVISIBLE = 0,
@@ -310,6 +311,7 @@ pub fn getbkgd(w: WINDOW) -> chtype
 pub fn getch() -> i32
 { unsafe { ll::getch() } }
 
+#[derive(Debug)]
 pub enum WchResult {
     KeyCode(i32),
     Char(winttype),

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -39,7 +39,7 @@ pub type va_list = *mut u8;
 
 /* Custom Types. */
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct MEVENT { pub id: c_short, pub x: c_int, pub y: c_int, pub z: c_int, pub bstate: mmask_t}
 
 extern {


### PR DESCRIPTION
This commit adds Debug implementations for all exported public types, and enables the `missing_debug_implementations` lint.

It also fixes some minor warnings in the other commits.