### PR TITLE
rerun the build script if PKG_CONFIG_PATH changes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,6 +19,8 @@ fn find_library(names: &[&str]) -> Option<Library> {
 }
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=PKG_CONFIG_PATH");
+
     let wide = cfg!(all(feature = "wide", not(target_os = "macos")));
 
     let ncurses_lib = if wide {


### PR DESCRIPTION
This forces the crate to relink the library if the user changes the
library search path. Otherwise, the old library would be reused, which
can cause surprising behavior.