### PR TITLE
Add mouse_v1 feature and detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ menu = []
 # Uses a 64-bit type for `chtype` (otherwise a 32-bit type is used).
 # This should be set automagically (when needed) by build.rs
 wide_chtype = []
+# Uses legacy values for mouse-related constants.
+mouse_v1 = []
 extended_colors = ["wide"]
 
 [lib]

--- a/build.rs
+++ b/build.rs
@@ -69,6 +69,10 @@ int main(void)
         /* We only support 32-bit and 64-bit chtype. */
         assert(sizeof(chtype)*CHAR_BIT == 32 && \"unsupported size for chtype\");
     }
+
+    if (NCURSES_MOUSE_VERSION == 1) {
+        puts(\"cargo:rustc-cfg=feature=\\\"mouse_v1\\\"\");
+    }
     return 0;
 }
     ").expect(&format!("cannot write into {}", src));

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -214,7 +214,12 @@ pub const KEY_EVENT: i32=	0x19b;		/* We were interrupted by an event */
 pub const KEY_MAX: i32=	0x1ff;		/* Maximum key value is 0633 */
 
 /* Mouse Support */
+#[cfg(feature="mouse_v1")]
+macro_rules! ncurses_mouse_mask( ($b:expr, $m:expr) => ($m << (($b - 1) * 6)); );
+
+#[cfg(not(feature="mouse_v1"))]
 macro_rules! ncurses_mouse_mask( ($b:expr, $m:expr) => ($m << (($b - 1) * 5)); );
+
 pub const NCURSES_BUTTON_RELEASED: i32=	0x001;
 pub const NCURSES_BUTTON_PRESSED: i32=		0x002;
 pub const NCURSES_BUTTON_CLICKED: i32=		0x004;
@@ -247,16 +252,45 @@ pub const BUTTON4_CLICKED: i32=        ncurses_mouse_mask!(4, NCURSES_BUTTON_CLI
 pub const BUTTON4_DOUBLE_CLICKED: i32= ncurses_mouse_mask!(4, NCURSES_DOUBLE_CLICKED);
 pub const BUTTON4_TRIPLE_CLICKED: i32= ncurses_mouse_mask!(4, NCURSES_TRIPLE_CLICKED);
 
+// These values depend on NCURSES_MOUSE_VERSION
+
+#[cfg(not(feature = "mouse_v1"))]
 pub const BUTTON5_RELEASED: i32=       ncurses_mouse_mask!(5, NCURSES_BUTTON_RELEASED);
+#[cfg(not(feature = "mouse_v1"))]
 pub const BUTTON5_PRESSED: i32=        ncurses_mouse_mask!(5, NCURSES_BUTTON_PRESSED);
+#[cfg(not(feature = "mouse_v1"))]
 pub const BUTTON5_CLICKED: i32=        ncurses_mouse_mask!(5, NCURSES_BUTTON_CLICKED);
+#[cfg(not(feature = "mouse_v1"))]
 pub const BUTTON5_DOUBLE_CLICKED: i32= ncurses_mouse_mask!(5, NCURSES_DOUBLE_CLICKED);
+#[cfg(not(feature = "mouse_v1"))]
 pub const BUTTON5_TRIPLE_CLICKED: i32= ncurses_mouse_mask!(5, NCURSES_TRIPLE_CLICKED);
 
+#[cfg(not(feature = "mouse_v1"))]
 pub const BUTTON_CTRL: i32=		ncurses_mouse_mask!(6, 0x001);
+#[cfg(not(feature = "mouse_v1"))]
 pub const BUTTON_SHIFT: i32=		ncurses_mouse_mask!(6, 0x002);
+#[cfg(not(feature = "mouse_v1"))]
 pub const BUTTON_ALT: i32=		ncurses_mouse_mask!(6, 0x004);
+#[cfg(not(feature = "mouse_v1"))]
 pub const REPORT_MOUSE_POSITION: i32=	ncurses_mouse_mask!(6, 0x008);
+
+#[cfg(feature = "mouse_v1")]
+pub const BUTTON1_RESERVED_EVENT: i32 = ncurses_mouse_mask!(1, NCURSES_RESERVED_EVENT);
+#[cfg(feature = "mouse_v1")]
+pub const BUTTON2_RESERVED_EVENT: i32 = ncurses_mouse_mask!(2, NCURSES_RESERVED_EVENT);
+#[cfg(feature = "mouse_v1")]
+pub const BUTTON3_RESERVED_EVENT: i32 = ncurses_mouse_mask!(3, NCURSES_RESERVED_EVENT);
+#[cfg(feature = "mouse_v1")]
+pub const BUTTON4_RESERVED_EVENT: i32 = ncurses_mouse_mask!(4, NCURSES_RESERVED_EVENT);
+#[cfg(feature = "mouse_v1")]
+pub const BUTTON_CTRL: i32=		ncurses_mouse_mask!(5, 0x001);
+#[cfg(feature = "mouse_v1")]
+pub const BUTTON_SHIFT: i32=		ncurses_mouse_mask!(5, 0x002);
+#[cfg(feature = "mouse_v1")]
+pub const BUTTON_ALT: i32=		ncurses_mouse_mask!(5, 0x004);
+#[cfg(feature = "mouse_v1")]
+pub const REPORT_MOUSE_POSITION: i32=	ncurses_mouse_mask!(5, 0x008);
+
 
 pub const ALL_MOUSE_EVENTS: i32=	REPORT_MOUSE_POSITION - 1;
 


### PR DESCRIPTION
This commits does 2 things:
* Add the `mouse_v1` feature. When enabled, some mouse-related constants have a different values.
* Detect the current `NCURSES_MOUSE_VERSION` in the build script, and enabled the `mouse_v1` feature if `NCURSES_MOUSE_VERSION == 1`.

Fixes #160 