### PR TITLE
Marked printw function as deprecated

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1105,7 +1105,7 @@ pub fn prefresh(pad: WINDOW, pmin_row: i32, pmin_col: i32, smin_row: i32, smin_c
 
 #[deprecated(since = "5.98.0", note = "printw can segfault when printing string that contains % sign. Use addstr instead")]
 pub fn printw(s: &str) -> i32
-{ ll::printw(s.to_c_str().as_ptr()) }
+{ unsafe { ll::printw(s.to_c_str().as_ptr()) } }
 
 
 pub fn putp(s: &str) -> i32

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1104,7 +1104,7 @@ pub fn prefresh(pad: WINDOW, pmin_row: i32, pmin_col: i32, smin_row: i32, smin_c
 
 
 #[deprecated(since = "5.98.0", note = "printw can segfault when printing string that contains % sign. Use addstr instead")]
-unsafe pub fn printw(s: &str) -> i32
+pub fn printw(s: &str) -> i32
 { ll::printw(s.to_c_str().as_ptr()) }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1103,8 +1103,9 @@ pub fn prefresh(pad: WINDOW, pmin_row: i32, pmin_col: i32, smin_row: i32, smin_c
 { unsafe { ll::prefresh(pad, pmin_row, pmin_col, smin_row, smin_col, smax_row, smax_col) } }
 
 
-pub fn printw(s: &str) -> i32
-{ unsafe { ll::printw(s.to_c_str().as_ptr()) } }
+#[deprecated(since = "5.98.0", note = "printw can segfault when printing string that contains % sign. Use addstr instead")]
+unsafe pub fn printw(s: &str) -> i32
+{ ll::printw(s.to_c_str().as_ptr()) }
 
 
 pub fn putp(s: &str) -> i32


### PR DESCRIPTION
Fixes #172, #149, #125