### PR TITLE
Fix memory corruption in locale string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1186,7 +1186,8 @@ pub fn scr_set(filename: &str) -> i32
 pub fn setlocale(lc: LcCategory, locale: &str) -> String
 {
   unsafe {
-    let buf = locale.to_c_str().as_ptr();
+    let c_str = locale.to_c_str();
+    let buf = c_str.as_ptr();
     let ret = ll::setlocale(lc as libc::c_int, buf);
     if ret == ptr::null() {
         String::new()


### PR DESCRIPTION
The wrapper for the ncurses `setlocale()` function converts the provided locale `&str` to a C string by creating a `std::ffi::CString`, then passing its inner pointer on to the ncurses function. This inner pointer outlived the `CString`'s temporary lifetime, so the data it pointed to was undefined when calling `setlocale()`. The fix is to bind the `CString` to a variable, thus extending its lifetime.

Most of the time this does not result in bad behavior, but if the memory being referred to by the pointer is overwritten before the call to `setlocale()`, then a garbage locale string may be used. Unable to find the locale, libc will fall back to a "C" locale, and attempts to print most Unicode characters will result in garbage characters being displayed on the terminal.

I haven't been able to reproduce this with a minimal example program, but in my Cursive-based program I can consistently reproduce this and have confirmed in gdb that the dropped memory becomes overwritten in the above fashion somewhere in `core::ptr::real_drop_in_place()`. This patch fixes the problem.