### PR TITLE
Use libc::setlocale

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -11,6 +11,8 @@
 */
 
 use libc::{ c_char, c_int };
+pub use libc::{LC_ALL, LC_COLLATE, LC_CTYPE, LC_MONETARY, LC_NUMERIC, LC_TIME, LC_MESSAGES};
+
 use super::ll::*;
 
 mod wrapped {
@@ -276,15 +278,6 @@ pub const BUTTON_ALT: i32 =            ncurses_mouse_mask!(MODIFIER_SHIFT, 0x004
 pub const REPORT_MOUSE_POSITION: i32 = ncurses_mouse_mask!(MODIFIER_SHIFT, 0x008);
 
 pub const ALL_MOUSE_EVENTS: i32=       REPORT_MOUSE_POSITION - 1;
-
-/* locales */
-pub const LC_ALL: c_int = 0;
-pub const LC_COLLATE: c_int = 1;
-pub const LC_CTYPE: c_int = 2;
-pub const LC_MONETARY: c_int = 3;
-pub const LC_NUMERIC: c_int = 4;
-pub const LC_TIME: c_int = 5;
-pub const LC_MESSAGES: c_int = 6;
 
 #[derive(Debug)]
 #[repr(i32)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1188,8 +1188,8 @@ pub fn setlocale(lc: LcCategory, locale: &str) -> String
   unsafe {
     let c_str = locale.to_c_str();
     let buf = c_str.as_ptr();
-    let ret = ll::setlocale(lc as libc::c_int, buf);
-    if ret == ptr::null() {
+    let ret = libc::setlocale(lc as libc::c_int, buf);
+    if ret == ptr::null_mut() {
         String::new()
     } else {
         // The clone is necessary, as the returned pointer
@@ -1333,11 +1333,11 @@ pub fn tigetnum(capname: &str) -> i32
 
 
 pub fn tigetstr(capname: &str) -> String
-{ unsafe { { FromCStr::from_c_str(ll::tigetstr(capname.to_c_str().as_ptr())) } } }
+{ unsafe { FromCStr::from_c_str(ll::tigetstr(capname.to_c_str().as_ptr())) } }
 
 
 pub fn tparm(s: &str) -> String
-{ unsafe { { FromCStr::from_c_str(ll::tparm(s.to_c_str().as_ptr())) } } }
+{ unsafe { FromCStr::from_c_str(ll::tparm(s.to_c_str().as_ptr())) } }
 
 
 pub fn ungetch(ch: i32) -> i32

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -221,7 +221,6 @@ extern {
     pub fn scrollok(_:WINDOW,_:c_bool) -> c_int;
     pub fn scr_restore(_:char_p) -> c_int;
     pub fn scr_set(_:char_p) -> c_int;
-    pub fn setlocale(_:c_int, _:char_p) -> char_p;
     pub fn setscrreg(_:c_int,_:c_int) -> c_int;
     pub fn set_term(_:SCREEN) -> SCREEN;
     pub fn set_escdelay(_:c_int) -> c_int;


### PR DESCRIPTION
This removes the `setlocale` binding, instead relying on the one from libc.
It also re-exports the `LC_ALL` & cie constants from libc, rather than re-defining them here.

This is more portable: `libc` goes to great length to support many platforms (with platform-dependents constants and links), no need to re-invent the wheel here.

Concretely, this fixes an issue with NetBSD where `setlocale` should actually link to `__setlocale50`. `libc` does it correctly, so let's just take that.