### PR TITLE
Fixed issue #198

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -62,7 +62,7 @@ fn main() {
 fn check_chtype_size(ncurses_lib: &Option<Library>) {
     let out_dir = env::var("OUT_DIR").expect("cannot get OUT_DIR");
     let src = format!("{}", Path::new(&out_dir).join("chtype_size.c").display());
-    let bin = format!("{}", Path::new(&out_dir).join("chtype_size").display());
+    let bin = format!("{}", Path::new(&out_dir).join(if cfg!(windows) { "chtype_size.exe" } else { "chtype_size" }).display());
 
     let mut fp = File::create(&src).expect(&format!("cannot create {}", src));
     fp.write_all(b"
@@ -98,13 +98,13 @@ int main(void)
     let mut command = compiler.to_command();
 
     if let Ok(x) = std::env::var("NCURSES_RS_CFLAGS") {
-      command.args(x.split(" "));
+        command.args(x.split(" "));
     }
 
     command.arg("-o").arg(&bin).arg(&src);
     assert!(command.status().expect("compilation failed").success());
     let features = Command::new(&bin).output()
-                   .expect(&format!("{} failed", bin));
+        .expect(&format!("{} failed", bin));
     print!("{}", String::from_utf8_lossy(&features.stdout));
 
     std::fs::remove_file(&src).expect(&format!("cannot delete {}", src));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1333,11 +1333,11 @@ pub fn tigetnum(capname: &str) -> i32
 
 
 pub fn tigetstr(capname: &str) -> String
-{ unsafe { { FromCStr::from_c_str(ll::tigetstr(capname.to_c_str().as_ptr())) } } }
+{ unsafe { FromCStr::from_c_str(ll::tigetstr(capname.to_c_str().as_ptr())) } }
 
 
 pub fn tparm(s: &str) -> String
-{ unsafe { { FromCStr::from_c_str(ll::tparm(s.to_c_str().as_ptr())) } } }
+{ unsafe { FromCStr::from_c_str(ll::tparm(s.to_c_str().as_ptr())) } }
 
 
 pub fn ungetch(ch: i32) -> i32


### PR DESCRIPTION
Formatted build.rs - aligned indents to 4 spaces
Fixed the warning in src/lib.rs - _unnecessary braces around block return value_