### PR TITLE
Fix build for NetBSD Curses

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -81,9 +81,9 @@ int main(void)
         assert(sizeof(chtype)*CHAR_BIT == 32 && \"unsupported size for chtype\");
     }
 
-    if (NCURSES_MOUSE_VERSION == 1) {
-        puts(\"cargo:rustc-cfg=feature=\\\"mouse_v1\\\"\");
-    }
+#if defined(NCURSES_MOUSE_VERSION) && NCURSES_MOUSE_VERSION == 1
+	puts(\"cargo:rustc-cfg=feature=\\\"mouse_v1\\\"\");
+#endif
     return 0;
 }
     ").expect(&format!("cannot write into {}", src));


### PR DESCRIPTION
`NCURSES_MOUSE_VERSION` is not defined in NetBSD Curses; This patch checks for NetBSD curses as NetBSD curses uses `#define _CURSES_H_` instead of `#define __NCURSES_H`