### PR TITLE
Makes `cursive` and `pancurses` compile with v6 of `ncurses-rs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ncurses"
-version = "6.0.0"
+version = "6.0.1"
 authors = [ "contact@jeaye.com" ]
 description = "A very thin wrapper around the ncurses TUI library"
 documentation = "https://github.com/jeaye/ncurses-rs"

--- a/src/genconstants.c
+++ b/src/genconstants.c
@@ -107,20 +107,20 @@ int main() {
 	PCONST(i32, KEY_ENTER);
 	PCONST(i32, KEY_PRINT);
 	PCONST(i32, KEY_LL);
-#ifdef A1
-	PCONST(i32, A1);
+#ifdef KEY_A1
+	PCONST(i32, KEY_A1);
 #endif
-#ifdef A3
-	PCONST(i32, A3);
+#ifdef KEY_A3
+	PCONST(i32, KEY_A3);
 #endif
-#ifdef B2
-	PCONST(i32, B2);
+#ifdef KEY_B2
+	PCONST(i32, KEY_B2);
 #endif
-#ifdef C1
-	PCONST(i32, C1);
+#ifdef KEY_C1
+	PCONST(i32, KEY_C1);
 #endif
-#ifdef C3
-	PCONST(i32, C3);
+#ifdef KEY_C3
+	PCONST(i32, KEY_C3);
 #endif
 	PCONST(i32, KEY_BTAB);
 	PCONST(i32, KEY_BEG);

--- a/src/genconstants.c
+++ b/src/genconstants.c
@@ -278,6 +278,9 @@ int main() {
 	PCONSTU(crate::ll::chtype, A_NORMAL);
 	PCONSTU(crate::ll::chtype, A_STANDOUT);
 	PCONSTU(crate::ll::chtype, A_UNDERLINE);
+#ifdef A_ITALIC
+	PCONSTU(crate::ll::chtype, A_ITALIC);
+#endif
 	PCONSTU(crate::ll::chtype, A_REVERSE);
 	PCONSTU(crate::ll::chtype, A_BLINK);
 	PCONSTU(crate::ll::chtype, A_DIM);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1769,7 +1769,8 @@ pub fn setsyx(y: &mut i32, x: &mut i32)
   }
 }
 
-pub fn KEY_F(n: u8) -> i32
+#[inline]
+pub const fn KEY_F(n: u8) -> i32
 {
   assert!(n < 16);
   KEY_F0 + n as i32


### PR DESCRIPTION
This was originally made in PR https://github.com/jeaye/ncurses-rs/pull/218 but now it's split off[^1] for easier reviewing and merging, because that PR also has a ton of build improvements too and it's too difficult to review.

With this PR, cursive and pancurses will compile afterwards but only if they also accept their own PRs which are https://github.com/gyscos/cursive/pull/778 respectively https://github.com/ihalila/pancurses/pull/93

Note, perhaps obvious to me, that currently `cursive` and `pancurses` cannot compile (without errors) with version `6.0.0` of `ncurses-rs` due to regressions that v6 introduced and also some incompatible changes, both of which this PR addresses, so they're stuck using version `5.101.0`

[^1]: technically that PR still contains everything this PR, so merging that one doesn't require this one as well. Ideally, that one would be merged instead of this one, but hey, the option to not merge that one(at all, ever) is now available, if we only care about making cursive&pancurses use our version 6 as soon as possible(well, 2 months late anyway :D)